### PR TITLE
Bug fixes and make rendering 3.4x faster

### DIFF
--- a/.agents/skills/implement-widget-tests/SKILL.md
+++ b/.agents/skills/implement-widget-tests/SKILL.md
@@ -56,12 +56,17 @@ from the same ratios the renderer uses — no hardcoded magic numbers.
 ## Imports
 
 ```python
+import re
+
 from custom_components.eink_dashboard.const import (
     COLOR_BLACK, COLOR_GRAY, PADDING, DEFAULT_CARD_STYLE,
 )
 from custom_components.eink_dashboard.render import (
     WidgetMetrics, _compute_metrics,
     _device_class_icon, render_dashboard,
+)
+from custom_components.eink_dashboard.svg_render import (
+    _DEFAULT_ROW_H, render_widget_svg,
 )
 from tests.helpers import (
     assert_all_white, assert_card_border, assert_has_dark_pixels,
@@ -131,6 +136,44 @@ coordinates.
 - Missing attributes: handles absent `device_class`, `friendly_name`
 - Edge cases: empty entity list, single entity
 
+### 5. Auto-sizing tests — row-based widgets only
+
+For row-based widgets (height derived from content rows), verify the
+auto-sizing fallback.  Use `render_widget_svg` directly — a
+full-canvas PNG from `render_dashboard` cannot reveal the widget's
+own height attribute.
+
+- **No `h`, one row**: `SVG height == _DEFAULT_ROW_H`
+- **No `h`, N rows**: `SVG height == N * _DEFAULT_ROW_H`
+- **Explicit `h` preserved**: widget with explicit `h` produces that
+  exact height regardless of row count
+
+```python
+def test_{widget}_auto_height_single_row(self) -> None:
+    # Without explicit h, one row produces height _DEFAULT_ROW_H.
+    w = {
+        "type": "$widget-type",
+        "x": 0, "y": 0, "w": 400,
+        "entities": ["sensor.temperature"],
+    }
+    svg = render_widget_svg(w, self._config())
+    m = re.search(r'height="(\d+)"', svg)
+    assert m is not None
+    assert int(m.group(1)) == _DEFAULT_ROW_H
+
+def test_{widget}_explicit_h_preserved(self) -> None:
+    # An explicit h overrides auto-sizing.
+    w = {
+        "type": "$widget-type",
+        "x": 0, "y": 0, "w": 400, "h": 200,
+        "entities": ["sensor.temperature"],
+    }
+    svg = render_widget_svg(w, self._config())
+    m = re.search(r'height="(\d+)"', svg)
+    assert m is not None
+    assert int(m.group(1)) == 200
+```
+
 ## Mock state setup
 
 Define mock states at **module level** (not pytest fixtures —
@@ -171,6 +214,8 @@ total widget height. All internal dimensions derive from `h`.
 
 ```python
 # Card-style widget (sensor_rows, waste_schedule, person, alarm)
+# "h" is optional: omit it for auto-sizing (height =
+# num_rows * _DEFAULT_ROW_H).  Include it to test explicit override.
 widget = {
     "type": "$widget-type",
     "x": PADDING, "y": 0, "w": 350, "h": 112,
@@ -299,6 +344,9 @@ m = _compute_metrics(56)  # row_h = widget h / number of rows
    inspect PNG output. Do NOT import or call internal drawing helpers
    from tests. The entry point (`render_dashboard`) dispatches
    transparently to the SVG pipeline in `svg_render.py`.
+   **Exception**: auto-sizing tests (§5) call `render_widget_svg`
+   directly to read the SVG `height` attribute — it cannot be inferred
+   from a full-canvas PNG.
 
 ## Font metric tolerance
 

--- a/.agents/skills/implement-widget-tests/SKILL.md
+++ b/.agents/skills/implement-widget-tests/SKILL.md
@@ -307,6 +307,13 @@ m = _compute_metrics(56)  # row_h = widget h / number of rows
 #   "none"     -> (0, 0)
 # Content width (cw):
 #   cw = w - x_off - right_inset
+# _row_content_pads(m, card_style, grayscale_levels) returns
+# (lpad, rpad): padding card_row applies inside the container.
+#   "border"   -> (0, 0)         container already provides both
+#   "left_bar" -> (0, m.padding) container covers left; row covers right
+#   "none"     -> (m.padding, m.padding)  row provides all padding
+# Icon circle left arc lands at x_off + lpad, NOT x_off + m.padding.
+# Divider lines span x_off + lpad .. w - right_inset - rpad.
 ```
 
 ## Lessons from completed TDD cycles

--- a/.agents/skills/implement-widget/SKILL.md
+++ b/.agents/skills/implement-widget/SKILL.md
@@ -59,6 +59,7 @@ lazily at call time.
 ```python
 from custom_components.eink_dashboard.const import (
     DEFAULT_CARD_STYLE,
+    PADDING,
 )
 from custom_components.eink_dashboard.render import (
     _compute_metrics,
@@ -67,7 +68,8 @@ from custom_components.eink_dashboard.render import (
 )
 ```
 
-`_mdi_svg_filter` and `_weather_svg_filter` are already in
+`_mdi_svg_filter`, `_weather_svg_filter`, `_widget_dim`,
+`_auto_row_height`, and `_DEFAULT_ROW_H` are already in
 `svg_render.py` — call them directly, no import needed.
 
 ## Macro usage notes
@@ -209,15 +211,16 @@ def _build_{widget_type}_context(
     """Build template context for $widget-type widget.
 
     Args:
-        widget: Widget config dict with x, y, w, h, entities,
-            card_style.
+        widget: Widget config dict with x, w, h, entities,
+            card_style, title.
         config: DisplayConfig with states and grayscale_levels.
 
     Returns:
         Template context dict.
     """
-    w = widget["w"]
-    h = widget["h"]
+    x = widget.get("x", PADDING)
+    w = _widget_dim(widget, "w", config["width"] - x)
+    title: str = widget.get("title", "")
     card_style = widget.get(
         "card_style", DEFAULT_CARD_STYLE
     )
@@ -227,7 +230,15 @@ def _build_{widget_type}_context(
 
     n = len(entities)
     if n == 0:
-        return {"w": w, "h": h, "rows": [], "m": None}
+        return {
+            "w": w,
+            "h": _widget_dim(widget, "h", _DEFAULT_ROW_H),
+            "rows": [],
+            "m": None,
+        }
+    # Row-based: auto-size height to fit n rows at
+    # _DEFAULT_ROW_H px each.  An explicit "h" overrides this.
+    h = _widget_dim(widget, "h", _auto_row_height(title, n))
     row_h = h // n
     m = _compute_metrics(row_h)
 
@@ -288,8 +299,9 @@ def _build_{widget_type}_context(
     config: DisplayConfig,
 ) -> dict[str, object]:
     """Build template context for $widget-type widget."""
-    w = widget["w"]
-    h = widget["h"]
+    x = widget.get("x", PADDING)
+    w = _widget_dim(widget, "w", config["width"] - x)
+    h = _widget_dim(widget, "h", _DEFAULT_ROW_H)
     entities = widget.get("entities", [])
     states = config.get("states", {})
     m = _compute_metrics(h)
@@ -411,3 +423,5 @@ behavior.
 - Icon name resolution: `_device_class_icon()` in `render.py`
 - Colors: `COLOR_BLACK=0`, `COLOR_WHITE=255`, `COLOR_GRAY=120`,
   `COLOR_LIGHT_GRAY=180` in `const.py`
+- Auto-sizing helpers: `_widget_dim`, `_auto_row_height`,
+  `_DEFAULT_ROW_H` in `svg_render.py` (no import needed)

--- a/.agents/skills/implement-widget/SKILL.md
+++ b/.agents/skills/implement-widget/SKILL.md
@@ -69,8 +69,8 @@ from custom_components.eink_dashboard.render import (
 ```
 
 `_mdi_svg_filter`, `_weather_svg_filter`, `_widget_dim`,
-`_auto_row_height`, and `_DEFAULT_ROW_H` are already in
-`svg_render.py` — call them directly, no import needed.
+`_auto_row_height`, `_row_content_pads`, and `_DEFAULT_ROW_H` are
+already in `svg_render.py` — call them directly, no import needed.
 
 ## Macro usage notes
 
@@ -84,7 +84,10 @@ from custom_components.eink_dashboard.render import (
 - **`card_row`** expects all sizes from `WidgetMetrics` fields plus
   `icon_svg` (pre-built SVG string, empty string for letter fallback)
   and `letter` (single uppercase char, empty string when icon_svg is
-  set). `primary` is the entity label; `secondary` is the state + unit.
+  set). `primary` is the entity label; `secondary` is the state +
+  unit. Pass `lpad`/`rpad` from `_row_content_pads()` to prevent
+  double-padding when a card style already provides insets; use the
+  same values for `x1`/`x2` of any divider `<line>` between rows.
 - **`chip`** requires pre-computed `w` because text width depends on
   font metrics unavailable in Jinja2. The context builder must compute
   chip widths using `_load_font(size).getlength(text)` from PIL — the
@@ -144,12 +147,13 @@ is opaque when composited onto the dashboard canvas:
     secondary=row.secondary,
     value=row.value,
     icon_svg=row.icon_svg,
-    letter=row.letter) }}
+    letter=row.letter,
+    lpad=lpad, rpad=rpad) }}
 {%- if not loop.last -%}
 <line
-  x1="{{ x_off + m.padding }}"
+  x1="{{ x_off + lpad }}"
   y1="{{ row.y + row_h }}"
-  x2="{{ w - r_inset - m.padding }}"
+  x2="{{ w - r_inset - rpad }}"
   y2="{{ row.y + row_h }}"
   stroke="#787878" stroke-width="{{ m.divider }}"/>
 {%- endif -%}
@@ -241,6 +245,9 @@ def _build_{widget_type}_context(
     h = _widget_dim(widget, "h", _auto_row_height(title, n))
     row_h = h // n
     m = _compute_metrics(row_h)
+    lpad, rpad = _row_content_pads(
+        m, card_style, grayscale_levels
+    )
 
     rows: list[dict[str, object]] = []
     for i, entity_id in enumerate(entities):
@@ -284,6 +291,8 @@ def _build_{widget_type}_context(
         "grayscale_levels": grayscale_levels,
         "rows": rows,
         "row_h": row_h,
+        "lpad": lpad,
+        "rpad": rpad,
     }
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         if: always()
         with:
           files: test-results.xml
+          check_name: Python Test Results
+          comment_title: Python Test Results
 
   frontend-typecheck:
     runs-on: ubuntu-latest
@@ -85,6 +87,8 @@ jobs:
         if: always()
         with:
           files: custom_components/eink_dashboard/frontend/test-results.xml
+          check_name: Frontend Test Results
+          comment_title: Frontend Test Results
 
   hacs-validate:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The component ships a WYSIWYG Lovelace card for editing the dashboard layout.
 | Sensor Rows | Label / value rows for a list of sensors |
 | Battery Bar | Horizontal battery level bar with percentage |
 | Status Icons | Row of filled/outline squares for binary sensors |
-| Waste Schedule | Upcoming waste collection dates (today, tomorrow, in N days) |
+| [Waste Schedule](docs/waste_schedule.md) | Upcoming waste collection dates (today, tomorrow, in N days) |
 
 All widgets support `x`, `y` positioning and `font_size`. Most support a `w`
 (width) override to constrain rendering to a sub-region of the display.

--- a/custom_components/eink_dashboard/frontend/src/eink-dashboard-card.ts
+++ b/custom_components/eink_dashboard/frontend/src/eink-dashboard-card.ts
@@ -259,6 +259,7 @@ class EinkDashboardCard extends HTMLElement {
         .scale-wrapper {
           position: relative;
           overflow: hidden;
+          border: 1px solid var(--divider-color, #e0e0e0);
         }
         .svg-canvas {
           position: absolute;
@@ -299,7 +300,7 @@ class EinkDashboardCard extends HTMLElement {
           gap: 6px;
           padding: 4px 8px;
           border-top: 1px solid var(--divider-color, #e0e0e0);
-          background: var(--card-background-color, #fff);
+          background: #e0e0e0;
         }
         .toggle-btn {
           font-size: 12px;
@@ -334,6 +335,7 @@ class EinkDashboardCard extends HTMLElement {
           font-weight: 500;
           color: var(--primary-text-color, #212121);
           line-height: 1.2;
+          background: #e0e0e0;
         }
         .copy-btn {
           font-size: 12px;

--- a/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
+++ b/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
@@ -129,6 +129,7 @@ export const WIDGET_TYPES: Record<string, WidgetTypeMeta> = {
       h: 168,
       entries: [],
       layout: "list",
+      show_all: false,
       card_style: DEFAULT_CARD_STYLE,
     },
   },
@@ -616,6 +617,11 @@ export const SCHEMAS: Record<
             },
           },
         },
+        {
+          name: "show_all",
+          default: false,
+          selector: { boolean: {} },
+        },
       ],
     },
     {
@@ -639,6 +645,12 @@ export const SCHEMAS: Record<
   ],
 };
 
+export const HELPERS: Record<string, string> = {
+  show_all:
+    "When off, the widget is empty if no collection falls "
+    + "within the next 3 days.",
+};
+
 export const LABELS: Record<string, string> = {
   text: "Text",
   entity: "Entity",
@@ -651,6 +663,7 @@ export const LABELS: Record<string, string> = {
   align: "Align",
   card_style: "Card style",
   layout: "Layout",
+  show_all: "Show all upcoming dates",
   entries: "Entries",
   forecast_days: "Forecast days",
 };
@@ -1113,6 +1126,7 @@ class EinkDashboardEditor extends HTMLElement {
     form.data = formData;
     form.schema = schemaFn(this._display);
     form.computeLabel = (s) => LABELS[s.name] || s.name;
+    form.computeHelper = (s) => HELPERS[s.name] || "";
     form.addEventListener(
       "value-changed",
       ((ev: CustomEvent<{ value: Record<string, unknown> }>) => {
@@ -1266,6 +1280,18 @@ class EinkDashboardEditor extends HTMLElement {
       "Select which waste types to display and set "
       + "short labels for each.";
     section.appendChild(hint);
+
+    const docHint = document.createElement("div");
+    docHint.className = "entries-hint";
+    const docLink = document.createElement("a");
+    docLink.href =
+      "https://github.com/cryptomilk/hass-eink-dashboard"
+      + "/blob/main/docs/waste_schedule.md";
+    docLink.target = "_blank";
+    docLink.rel = "noopener noreferrer";
+    docLink.textContent = "Setup guide";
+    docHint.appendChild(docLink);
+    section.appendChild(docHint);
 
     // Build a lookup for existing entries
     const existing = new Map<string, string>();

--- a/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
+++ b/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
@@ -47,6 +47,7 @@ export interface HaFormElement extends HTMLElement {
   data: Record<string, unknown>;
   schema: HaFormSchema[];
   computeLabel: (schema: HaFormSchema) => string;
+  computeHelper: (schema: HaFormSchema) => string;
 }
 
 export interface HaSelectOption {
@@ -183,6 +184,7 @@ export interface WasteScheduleWidget extends WidgetBase {
   entity?: string;
   entries?: WasteScheduleEntry[];
   layout?: "list" | "card";
+  show_all?: boolean;
   card_style?: CardStyle;
 }
 

--- a/custom_components/eink_dashboard/render.py
+++ b/custom_components/eink_dashboard/render.py
@@ -1,11 +1,12 @@
 """Dashboard rendering orchestrator and shared utility helpers.
 
 Thin wrapper around the SVG pipeline in ``svg_render.py``.
-``render_dashboard()`` composes per-widget SVGs, rasterises with
-resvg, and applies rotation plus e-ink optimisation.  Shared
-helpers (``_load_font``, ``_compute_metrics``, ``_fmt_temp``, etc.)
-live here to avoid circular imports — ``svg_render.py`` imports
-them lazily at call time.
+``render_dashboard()`` rasterises each widget SVG individually,
+pastes onto a canvas, and applies rotation plus e-ink
+optimisation.  Shared helpers (``_load_font``,
+``_compute_metrics``, ``_fmt_temp``, etc.) live here to avoid
+circular imports — ``svg_render.py`` imports them lazily at call
+time.
 """
 
 from __future__ import annotations
@@ -24,7 +25,6 @@ from .const import PADDING
 from .optimize import optimize_for_eink
 from .svg_render import (
     _SVG_RENDERERS,
-    _compose_svg,
     _svg_to_png,
     render_widget_svg,
 )
@@ -371,11 +371,13 @@ def render_dashboard(
     widget_list: list[Widget],
     config: DisplayConfig,
 ) -> bytes:
-    """Render all widgets into a single SVG, rasterise, and return PNG.
+    """Render widgets to PNG bytes for e-ink display.
 
-    Collects per-widget SVG strings, composes them into one root SVG
-    document via ``_compose_svg``, rasterises the result with a single
-    ``resvg`` call, then applies rotation and e-ink optimisation.
+    Rasterises each widget SVG individually at its intrinsic size,
+    pastes the results onto a white canvas, then applies rotation
+    and e-ink optimisation.  Per-widget rasterisation is ~3x faster
+    than composing one large SVG because resvg's cost scales with
+    document complexity and pixmap area.
 
     Args:
         widget_list: Widget configuration dicts.  Each must have a
@@ -391,9 +393,8 @@ def render_dashboard(
     w = config["width"]
     h = config["height"]
 
-    # Collect SVG strings and canvas positions for each widget.
-    svg_parts: list[str] = []
-    positions: list[tuple[int, int]] = []
+    img = Image.new("L", (w, h), 255)
+
     for widget in widget_list:
         widget_type = widget.get("type")
         if widget_type is None:
@@ -416,12 +417,10 @@ def render_dashboard(
             wx,
             wy,
         )
-        svg_parts.append(render_widget_svg(widget, config))
-        positions.append((wx, wy))
-
-    composed = _compose_svg(svg_parts, positions, w, h)
-    png = _svg_to_png(composed, w, h)
-    img = Image.open(io.BytesIO(png)).convert("L")
+        svg = render_widget_svg(widget, config)
+        png = _svg_to_png(svg)
+        wimg = Image.open(io.BytesIO(png)).convert("L")
+        img.paste(wimg, (wx, wy))
 
     mn, mx = img.getextrema()
     _LOGGER.debug(

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -428,6 +428,8 @@ def _auto_row_height(
     Returns:
         Total widget height in pixels.
     """
+    if num_rows < 1:
+        raise ValueError(f"num_rows must be >= 1, got {num_rows}")
     target = num_rows * row_h
     if not title:
         return target
@@ -1186,7 +1188,7 @@ def _build_device_battery_context(
     x = widget.get("x", PADDING)
     svg_w = _widget_dim(widget, "w", config["width"] - x)
     h: int = widget.get("h", 40)
-    svg_h = _widget_dim(widget, "h", h)
+    svg_h = _widget_dim(widget, "h", 40)
 
     level = config.get("device_battery_level")
     if level is None:
@@ -1203,7 +1205,7 @@ def _build_device_battery_context(
     color_hex = f"#{color:02x}{color:02x}{color:02x}"
 
     label = f"{pct}%"
-    m = _compute_metrics(h)
+    m = _compute_metrics(svg_h)
 
     x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
 

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -443,6 +443,52 @@ def _auto_row_height(
     return svg_h
 
 
+def _row_content_pads(
+    m: Any,
+    card_style: str,
+    grayscale_levels: int = 16,
+) -> tuple[int, int]:
+    """Return (lpad, rpad) for a card_row inside a card_container.
+
+    The ``card_container`` macro already insets the content area via
+    ``_card_insets``.  Without adjustment, ``card_row`` would add
+    its own ``padding`` on top, resulting in double-padding.
+
+    This function derives ``lpad``/``rpad`` directly from
+    ``_card_insets`` so both stay in sync: when the container
+    provides a non-zero inset on a side, the row contributes zero
+    padding on that side; when the container provides no inset, the
+    row supplies the full ``m.padding``.
+
+    Resulting total insets from card edge to content:
+    - ``"border"``: ``m.padding`` on both sides (container left +
+      right, row adds nothing).
+    - ``"left_bar"``: ``bar_w + m.padding`` on the left (container
+      provides both bar and padding offset), ``m.padding`` on the
+      right (row only, container has zero right inset).
+    - ``"none"``: ``m.padding`` on both sides (row only, container
+      has zero insets on both sides).
+
+    Args:
+        m: ``WidgetMetrics`` from ``_compute_metrics``.
+        card_style: One of ``"border"``, ``"left_bar"``, or
+            ``"none"`` (or any unrecognised value treated as
+            ``"none"``).
+        grayscale_levels: Forwarded to ``_card_insets`` so the
+            ``"left_bar"`` width is computed correctly on 2-level
+            displays.
+
+    Returns:
+        ``(lpad, rpad)`` — left and right padding for the
+        ``card_row`` macro.  Rows should pass these as
+        ``lpad=lpad, rpad=rpad``.
+    """
+    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
+    lpad = m.padding if x_off == 0 else 0
+    rpad = m.padding if r_inset == 0 else 0
+    return lpad, rpad
+
+
 def _build_text_context(
     widget: Widget,
     config: DisplayConfig,
@@ -1055,6 +1101,7 @@ def _build_sensor_rows_context(
     title_font_sz, content_y, content_h = _title_layout(title, svg_h)
     row_h = content_h // len(entity_ids)
     m = _compute_metrics(row_h)
+    lpad, rpad = _row_content_pads(m, card_style, grayscale_levels)
 
     rows: list[dict[str, object]] = []
     for i, entity_id in enumerate(entity_ids):
@@ -1110,6 +1157,8 @@ def _build_sensor_rows_context(
         "m_divider": m.divider,
         "row_h": row_h,
         "rows": rows,
+        "lpad": lpad,
+        "rpad": rpad,
     }
 
 
@@ -1600,6 +1649,7 @@ def _build_waste_schedule_context(
     row_h = content_h // num_display_rows
 
     m = _compute_metrics(row_h)
+    lpad, rpad = _row_content_pads(m, card_style, grayscale_levels)
 
     # Build the trash-can icon SVG once; all entries share the
     # same icon, only the circle fill/outline differs.
@@ -1651,6 +1701,8 @@ def _build_waste_schedule_context(
         "m_divider": m.divider,
         "row_h": row_h,
         "rows": rows,
+        "lpad": lpad,
+        "rpad": rpad,
     }
 
 

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -83,7 +83,7 @@ _ACTIVE_STATES: frozenset[str] = frozenset(
 
 def _svg_to_png(
     svg: str,
-    width: int,
+    width: int | None = None,
     height: int | None = None,
 ) -> bytes:
     """Rasterise an SVG string to PNG bytes via resvg.
@@ -92,16 +92,16 @@ def _svg_to_png(
     HA OS, Docker, and dev machines.  Only fonts shipped in the
     ``fonts/`` directory are available to the renderer.
 
-    When ``height`` is ``None``, resvg uses the SVG document's
-    intrinsic height.  Widgets whose content can exceed their
-    declared ``h`` (e.g. ``status_icons`` with wrapping chips)
-    set the SVG height to the full content height and omit the
-    explicit override so the rasterised PNG is tall enough to hold
-    all rows.
+    When ``width`` or ``height`` is ``None``, resvg uses the SVG
+    document's intrinsic dimension.  There are two usage modes:
+    pass both as ``None`` (production per-widget rendering) so
+    each widget renders at its declared size; or pass explicit
+    values to scale to a fixed viewport (design tool, tests).
 
     Args:
         svg: SVG document as a string.
-        width: Output width in pixels.
+        width: Output width in pixels, or ``None`` to use the
+            SVG's intrinsic width.
         height: Output height in pixels, or ``None`` to use the
             SVG's intrinsic height.
 

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -398,6 +398,51 @@ def _widget_dim(widget: Widget, key: str, fallback: int) -> int:
     return max(1, widget.get(key, fallback))
 
 
+# Default row height for auto-sizing row-based widgets.  Produces
+# readable metrics via _compute_metrics(56): font_primary=18,
+# icon_dia=36, padding=12, inner_gap=12.
+_DEFAULT_ROW_H = 56
+
+
+def _auto_row_height(
+    title: str,
+    num_rows: int,
+    row_h: int = _DEFAULT_ROW_H,
+) -> int:
+    """Compute natural widget height from content row count.
+
+    Returns a height such that when ``_title_layout(title, result)``
+    is called the resulting ``content_h`` equals ``num_rows * row_h``
+    (within 1 px rounding).  When ``title`` is empty, this simplifies
+    to ``num_rows * row_h``.
+
+    Used as the fallback for ``_widget_dim`` so row-based widgets size
+    to their content instead of filling the remaining canvas.
+
+    Args:
+        title: Widget title string.  Empty means no title.
+        num_rows: Number of content rows to accommodate.
+            Must be at least 1.
+        row_h: Target height per content row in pixels.
+
+    Returns:
+        Total widget height in pixels.
+    """
+    target = num_rows * row_h
+    if not title:
+        return target
+    # _title_layout subtracts an advance from svg_h, creating a
+    # dependency: advance depends on svg_h.  Iterate to find the
+    # fixpoint.  round() in _title_layout creates a 1-px staircase
+    # that can cause a 1-step oscillation, so 3 iterations (not 2)
+    # guarantee convergence to within ±1 px of target.
+    svg_h = target
+    for _ in range(3):
+        _, _, content_h = _title_layout(title, svg_h)
+        svg_h = svg_h + (target - content_h)
+    return svg_h
+
+
 def _build_text_context(
     widget: Widget,
     config: DisplayConfig,
@@ -963,9 +1008,9 @@ def _build_sensor_rows_context(
 
     Args:
         widget: Widget config dict.  Recognised keys:
-            ``x`` (default ``PADDING``), ``y`` (default 0),
+            ``x`` (default ``PADDING``),
             ``w`` (default remaining canvas width),
-            ``h`` (default remaining canvas height),
+            ``h`` (default content height; auto-sized when absent),
             ``entities`` (list of entity IDs),
             ``title`` (optional section label drawn above
             the card), ``card_style``.
@@ -984,9 +1029,7 @@ def _build_sensor_rows_context(
     )
 
     x = widget.get("x", PADDING)
-    y = widget.get("y", 0)
     svg_w = _widget_dim(widget, "w", config["width"] - x)
-    svg_h = _widget_dim(widget, "h", config["height"] - y)
 
     entity_ids: list[str] = widget.get("entities", [])
     card_style = widget.get("card_style", DEFAULT_CARD_STYLE)
@@ -999,8 +1042,16 @@ def _build_sensor_rows_context(
     # Absent entities would otherwise leave silent blank gaps.
     entity_ids = [eid for eid in entity_ids if eid in states]
     if not entity_ids:
-        return {"w": svg_w, "h": svg_h, "has_entities": False}
+        return {
+            "w": svg_w,
+            "h": _widget_dim(widget, "h", _DEFAULT_ROW_H),
+            "has_entities": False,
+        }
 
+    # Auto-size: default to content height so the widget is no
+    # taller than its rendered rows.  Explicit "h" in the widget
+    # config overrides this, preserving backward compatibility.
+    svg_h = _widget_dim(widget, "h", _auto_row_height(title, len(entity_ids)))
     title_font_sz, content_y, content_h = _title_layout(title, svg_h)
     row_h = content_h // len(entity_ids)
     m = _compute_metrics(row_h)
@@ -1463,7 +1514,7 @@ def _build_waste_schedule_context(
             ``entries`` (list of ``{"attribute": …, "label": …}``
             dicts), ``layout`` (``"list"`` or ``"card"``),
             ``show_all`` (``bool``, default ``False``),
-            ``card_style``, ``title``, ``x``, ``y``, ``w``, ``h``.
+            ``card_style``, ``title``, ``x``, ``w``, ``h``.
         config: Display config with ``states`` (entity ID →
             state dict) and ``grayscale_levels``.
 
@@ -1482,9 +1533,7 @@ def _build_waste_schedule_context(
     )
 
     x = widget.get("x", PADDING)
-    y = widget.get("y", 0)
     svg_w = _widget_dim(widget, "w", config["width"] - x)
-    svg_h = _widget_dim(widget, "h", config["height"] - y)
 
     entity_id: str = widget.get("entity", "")
     entries: list[dict[str, str]] = widget.get("entries", [])
@@ -1497,7 +1546,7 @@ def _build_waste_schedule_context(
 
     empty_ctx: dict[str, object] = {
         "w": svg_w,
-        "h": svg_h,
+        "h": _widget_dim(widget, "h", _DEFAULT_ROW_H),
         "has_rows": False,
     }
     if not entity_id or not entries:
@@ -1508,9 +1557,9 @@ def _build_waste_schedule_context(
         return empty_ctx
 
     attrs = entity_state.get("attributes", {})
-    title_font_sz, content_y, content_h = _title_layout(title, svg_h)
 
-    # Resolve visible entries: parse dates, filter to 0–3 days.
+    # Resolve visible entries before computing height so the
+    # auto-sizing fallback knows how many rows to accommodate.
     # Config order is preserved — equal-day entries keep the
     # order the user configured them, matching the PIL renderer.
     # Use _get_today() from render.py so tests can patch
@@ -1539,9 +1588,16 @@ def _build_waste_schedule_context(
         # config order), displayed at full widget height.
         visible.sort(key=lambda e: e[2])
         visible = [visible[0]]
-        row_h = content_h
-    else:
-        row_h = content_h // len(visible)
+
+    # Auto-size: default to content height so the widget is no
+    # taller than its rendered rows.  Explicit "h" in the widget
+    # config overrides this, preserving backward compatibility.
+    num_display_rows = len(visible)
+    svg_h = _widget_dim(widget, "h", _auto_row_height(title, num_display_rows))
+    title_font_sz, content_y, content_h = _title_layout(title, svg_h)
+    # card layout always trims visible to one entry above, so
+    # num_display_rows == 1 and the division is equivalent to content_h.
+    row_h = content_h // num_display_rows
 
     m = _compute_metrics(row_h)
 

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -322,7 +322,8 @@ def _title_layout(
         ``(title_font_sz, content_y, content_h)`` where
         ``title_font_sz`` is 0 when ``title`` is empty,
         ``content_y`` is the top of the card area (below the
-        title), and ``content_h`` is the remaining height.
+        title, or 0 when ``title`` is empty), and
+        ``content_h`` is the remaining height.
     """
     if not title:
         return 0, 0, svg_h
@@ -352,12 +353,14 @@ def _card_insets(
     m: WidgetMetrics,
     card_style: str,
     grayscale_levels: int,
-) -> tuple[int, int]:
-    """Return (x_off, r_inset) for a card container.
+) -> tuple[int, int, int]:
+    """Return (x_off, r_inset, bar_width) for a card container.
 
-    Mirrors the inset logic in the ``card_container`` macro in
-    ``templates/_macros.svg.j2`` so callers can pre-compute
-    absolute positions in Python rather than in Jinja2.
+    The ``card_container`` macro in ``_macros.svg.j2`` is purely
+    decorative; all content positioning uses these insets computed
+    in Python.  ``bar_width`` is the pre-computed left-bar width
+    (including 2-level widening) so the macro never recalculates
+    it — Python is the single source of truth.
 
     Args:
         m: ``WidgetMetrics`` dataclass from ``_compute_metrics``.
@@ -368,16 +371,18 @@ def _card_insets(
             displays.
 
     Returns:
-        ``(x_off, r_inset)`` — the left and right pixel insets
-        for the content area inside the card frame.
+        ``(x_off, r_inset, bar_width)`` — the left and right
+        pixel insets for the content area inside the card frame,
+        and the rendered bar width (0 when not ``"left_bar"``).
     """
     from .render import _left_bar_width  # noqa: PLC0415
 
     if card_style == "border":
-        return m.padding, m.padding
+        return m.padding, m.padding, 0
     if card_style == "left_bar":
-        return _left_bar_width(m, grayscale_levels) + m.padding, 0
-    return 0, 0
+        bar_w = _left_bar_width(m, grayscale_levels)
+        return bar_w + m.padding, 0, bar_w
+    return 0, 0, 0
 
 
 def _widget_dim(widget: Widget, key: str, fallback: int) -> int:
@@ -446,52 +451,6 @@ def _auto_row_height(
     return svg_h
 
 
-def _row_content_pads(
-    m: WidgetMetrics,
-    card_style: str,
-    grayscale_levels: int,
-) -> tuple[int, int]:
-    """Return (lpad, rpad) for a card_row inside a card_container.
-
-    The ``card_container`` macro already insets the content area via
-    ``_card_insets``.  Without adjustment, ``card_row`` would add
-    its own ``padding`` on top, resulting in double-padding.
-
-    This function derives ``lpad``/``rpad`` directly from
-    ``_card_insets`` so both stay in sync: when the container
-    provides a non-zero inset on a side, the row contributes zero
-    padding on that side; when the container provides no inset, the
-    row supplies the full ``m.padding``.
-
-    Resulting total insets from card edge to content:
-    - ``"border"``: ``m.padding`` on both sides (container left +
-      right, row adds nothing).
-    - ``"left_bar"``: ``bar_w + m.padding`` on the left (container
-      provides both bar and padding offset), ``m.padding`` on the
-      right (row only, container has zero right inset).
-    - ``"none"``: ``m.padding`` on both sides (row only, container
-      has zero insets on both sides).
-
-    Args:
-        m: ``WidgetMetrics`` from ``_compute_metrics``.
-        card_style: One of ``"border"``, ``"left_bar"``, or
-            ``"none"`` (or any unrecognised value treated as
-            ``"none"``).
-        grayscale_levels: Forwarded to ``_card_insets`` so the
-            ``"left_bar"`` width is computed correctly on 2-level
-            displays.
-
-    Returns:
-        ``(lpad, rpad)`` — left and right padding for the
-        ``card_row`` macro.  Rows should pass these as
-        ``lpad=lpad, rpad=rpad``.
-    """
-    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
-    lpad = m.padding if x_off == 0 else 0
-    rpad = m.padding if r_inset == 0 else 0
-    return lpad, rpad
-
-
 def _build_text_context(
     widget: Widget,
     config: DisplayConfig,
@@ -526,7 +485,7 @@ def _build_text_context(
         ``text_x``, ``text_y``, ``text_anchor``, ``baseline``);
         optional title attributes (``title``, ``title_font_sz``,
         ``title_x``); card container inputs (``card_style``,
-        ``content_y``, ``content_h``, ``grayscale_levels``,
+        ``content_y``, ``content_h``, ``bar_width``,
         ``m_border``, ``m_padding``, ``m_radius``,
         ``m_left_bar``).
     """
@@ -551,9 +510,7 @@ def _build_text_context(
     title_font_sz, content_y, content_h = _title_layout(title, svg_h)
     m = _compute_metrics(content_h)
 
-    # Compute card container insets — mirrors the card_container
-    # macro's own logic so text_x can be pre-calculated in Python.
-    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
+    x_off, r_inset, bar_width = _card_insets(m, card_style, grayscale_levels)
 
     content_w = svg_w - x_off - r_inset
 
@@ -605,7 +562,7 @@ def _build_text_context(
         "content_y": content_y,
         "content_h": content_h,
         "card_style": card_style,
-        "grayscale_levels": grayscale_levels,
+        "bar_width": bar_width,
         **_metrics_context(m),
     }
 
@@ -814,11 +771,14 @@ def _build_weather_context(
     # Content insets — "border" and "left_bar" use the shared
     # helper; "none" applies its own pad so that the weather card
     # content never touches the viewport edge.
-    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
     if card_style == "none":
         content_left = pad
         content_w = card_w - 2 * pad
+        bar_width = 0
     else:
+        x_off, r_inset, bar_width = _card_insets(
+            m, card_style, grayscale_levels
+        )
         content_left = x_off
         content_w = card_w - x_off - r_inset
 
@@ -1011,7 +971,7 @@ def _build_weather_context(
         "total_h": total_h,
         "card_style": card_style,
         **_metrics_context(m),
-        "grayscale_levels": grayscale_levels,
+        "bar_width": bar_width,
         "icon_svg": cond_icon_svg,
         "icon_x": icon_x,
         "icon_y": icon_y,
@@ -1098,7 +1058,12 @@ def _build_sensor_rows_context(
     title_font_sz, content_y, content_h = _title_layout(title, svg_h)
     row_h = content_h // len(entity_ids)
     m = _compute_metrics(row_h)
-    lpad, rpad = _row_content_pads(m, card_style, grayscale_levels)
+    x_off, r_inset, bar_width = _card_insets(m, card_style, grayscale_levels)
+    # When the card container already insets content on a side,
+    # the row contributes zero padding on that side to avoid
+    # double-padding.
+    lpad = m.padding if x_off == 0 else 0
+    rpad = m.padding if r_inset == 0 else 0
 
     rows: list[dict[str, object]] = []
     for i, entity_id in enumerate(entity_ids):
@@ -1145,10 +1110,12 @@ def _build_sensor_rows_context(
         "content_y": content_y,
         "content_h": content_h,
         "card_style": card_style,
-        "grayscale_levels": grayscale_levels,
+        "bar_width": bar_width,
         **_metrics_context(m),
         "row_h": row_h,
         "rows": rows,
+        "x_off": x_off,
+        "r_inset": r_inset,
         "lpad": lpad,
         "rpad": rpad,
     }
@@ -1210,7 +1177,7 @@ def _build_device_battery_context(
     label = f"{pct}%"
     m = _compute_metrics(svg_h)
 
-    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
+    x_off, r_inset, bar_width = _card_insets(m, card_style, grayscale_levels)
 
     if layout == "chip":
         content_w = svg_w - x_off - r_inset
@@ -1245,10 +1212,10 @@ def _build_device_battery_context(
             "h": svg_h,
             "has_level": True,
             "layout": "chip",
-            "card_h": h,
+            "card_h": svg_h,
             "card_style": card_style,
             **_metrics_context(m),
-            "grayscale_levels": grayscale_levels,
+            "bar_width": bar_width,
             "color_hex": color_hex,
             "label": label,
             "font_sz": font_sz,
@@ -1303,10 +1270,10 @@ def _build_device_battery_context(
         "h": svg_h,
         "has_level": True,
         "layout": "icon",
-        "card_h": h,
+        "card_h": svg_h,
         "card_style": card_style,
         **_metrics_context(m),
-        "grayscale_levels": grayscale_levels,
+        "bar_width": bar_width,
         "color_hex": color_hex,
         "label": label,
         "font_sz": font_sz,
@@ -1402,7 +1369,7 @@ def _build_status_icons_context(
     chip_h = max(1, content_h)
     m = _compute_metrics(chip_h)
 
-    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
+    x_off, r_inset, bar_width = _card_insets(m, card_style, grayscale_levels)
     content_w = svg_w - x_off - r_inset
 
     show_icon: bool = widget.get("show_icon", True)
@@ -1516,7 +1483,7 @@ def _build_status_icons_context(
         "title_advance": title_advance,
         "chip_h": chip_h,
         "card_style": card_style,
-        "grayscale_levels": grayscale_levels,
+        "bar_width": bar_width,
         **_metrics_context(m),
         "chips": chips,
     }
@@ -1643,7 +1610,9 @@ def _build_waste_schedule_context(
     row_h = content_h // num_display_rows
 
     m = _compute_metrics(row_h)
-    lpad, rpad = _row_content_pads(m, card_style, grayscale_levels)
+    x_off, r_inset, bar_width = _card_insets(m, card_style, grayscale_levels)
+    lpad = m.padding if x_off == 0 else 0
+    rpad = m.padding if r_inset == 0 else 0
 
     # Build the trash-can icon SVG once; all entries share the
     # same icon, only the circle fill/outline differs.
@@ -1686,10 +1655,12 @@ def _build_waste_schedule_context(
         "content_y": content_y,
         "content_h": content_h,
         "card_style": card_style,
-        "grayscale_levels": grayscale_levels,
+        "bar_width": bar_width,
         **_metrics_context(m),
         "row_h": row_h,
         "rows": rows,
+        "x_off": x_off,
+        "r_inset": r_inset,
         "lpad": lpad,
         "rpad": rpad,
     }

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -152,6 +152,8 @@ def _compose_svg(
     for svg, (x, y) in zip(svg_parts, positions, strict=True):
         # Strip leading whitespace then replace '<svg ' prefix so
         # that x/y attributes position the widget viewport.
+        # Templates must emit '<svg ' (space after tag name, not
+        # a newline) for this prefix swap to work.
         stripped = svg.lstrip()
         if not stripped.startswith("<svg "):
             raise ValueError(f"expected <svg prefix: {stripped[:40]!r}")
@@ -786,8 +788,10 @@ def _build_weather_context(
     temp_bbox = font_xl.getbbox(temp_text)
     temp_h = temp_bbox[3] - temp_bbox[1]
 
-    # Card metrics — always compute so they can be passed to the
-    # card_container macro even when card_style is "none".
+    # Card metrics — 48 at scale=1 gives card-level metrics
+    # (padding~10, radius~10) matching the original PIL layout.
+    # Always compute so they can be passed to the card_container
+    # macro even when card_style is "none".
     m = _compute_metrics(round(48 * scale))
     top_pad = m.padding if card_style != "none" else pad
 
@@ -1374,6 +1378,8 @@ def _build_status_icons_context(
 
     x = widget.get("x", PADDING)
     svg_w = _widget_dim(widget, "w", config["width"] - x)
+    # Chip wrapping determines total_h dynamically, so
+    # _auto_row_height (fixed row count) does not apply here.
     svg_h = _widget_dim(widget, "h", 40)
     title: str = widget.get("title", "")
     card_style: str = widget.get("card_style", DEFAULT_CARD_STYLE)

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -720,7 +720,6 @@ def _build_weather_context(
         _DAY_ABBREV,
         _compute_metrics,
         _fmt_temp,
-        _left_bar_width,
         _load_font,
     )
 
@@ -807,23 +806,16 @@ def _build_weather_context(
     # the full remaining canvas when no explicit h is configured.
     svg_h = _widget_dim(widget, "h", total_h)
 
-    # Content insets — mirror the card_container macro in
-    # templates/_macros.svg.j2 (macro card_container, lines 41-74).
-    # The macro's caller(xo, ri) values are intentionally unused in
-    # the template; all positions are pre-computed here so they stay
-    # in Python, not Jinja2.
+    # Content insets — "border" and "left_bar" use the shared
+    # helper; "none" applies its own pad so that the weather card
+    # content never touches the viewport edge.
+    x_off, r_inset = _card_insets(m, card_style, grayscale_levels)
     if card_style == "none":
         content_left = pad
         content_w = card_w - 2 * pad
-    elif card_style == "border":
-        content_left = m.padding
-        content_w = card_w - 2 * m.padding
-    elif card_style == "left_bar":
-        content_left = _left_bar_width(m, grayscale_levels) + m.padding
-        content_w = card_w - content_left
     else:
-        content_left = 0
-        content_w = card_w
+        content_left = x_off
+        content_w = card_w - x_off - r_inset
 
     content_top = top_pad
 

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -12,12 +12,17 @@ Icon SVG files are inlined as ``<path>`` elements via Jinja2 filters
 occurs only once per icon per process lifetime.
 """
 
+from __future__ import annotations
+
 import contextlib
 import functools
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .render import WidgetMetrics
 from xml.sax.saxutils import quoteattr
 
 import defusedxml.ElementTree as ET
@@ -323,32 +328,27 @@ def _title_layout(
     return font_sz, advance, svg_h - advance
 
 
-def _metrics_context(m: Any) -> dict[str, int]:
-    """Return the base card metric fields for a Jinja2 template context.
+def _metrics_context(m: WidgetMetrics) -> dict[str, object]:
+    """Return all metric fields for a Jinja2 template context.
 
-    Extracts the four fields that every card-style widget passes to its
-    template (``m_border``, ``m_padding``, ``m_radius``,
-    ``m_left_bar``).  Call sites merge this dict into the full context
-    with ``**_metrics_context(m)`` and add extra metric fields
-    (``m_icon_dia`` etc.) individually when needed.
+    Serialises every ``WidgetMetrics`` field into a ``m_``-prefixed
+    dict so templates can reference any metric without the Python
+    context builder having to cherry-pick individual fields.
 
     Args:
-        m: ``WidgetMetrics`` namedtuple from ``_compute_metrics``.
+        m: ``WidgetMetrics`` dataclass from ``_compute_metrics``.
 
     Returns:
-        Dict with four ``m_*`` keys ready to unpack into a context
-        dict.
+        Dict with ``m_*`` keys for every ``WidgetMetrics`` field,
+        ready to unpack into a template context dict.
     """
-    return {
-        "m_border": m.border,
-        "m_padding": m.padding,
-        "m_radius": m.radius,
-        "m_left_bar": m.left_bar,
-    }
+    from dataclasses import fields as dc_fields  # noqa: PLC0415
+
+    return {f"m_{f.name}": getattr(m, f.name) for f in dc_fields(m)}
 
 
 def _card_insets(
-    m: Any,
+    m: WidgetMetrics,
     card_style: str,
     grayscale_levels: int,
 ) -> tuple[int, int]:
@@ -359,7 +359,7 @@ def _card_insets(
     absolute positions in Python rather than in Jinja2.
 
     Args:
-        m: ``WidgetMetrics`` namedtuple from ``_compute_metrics``.
+        m: ``WidgetMetrics`` dataclass from ``_compute_metrics``.
         card_style: One of ``"border"``, ``"left_bar"``, or
             ``"none"`` (or any other value treated as ``"none"``).
         grayscale_levels: Display grayscale depth; passed to
@@ -444,7 +444,7 @@ def _auto_row_height(
 
 
 def _row_content_pads(
-    m: Any,
+    m: WidgetMetrics,
     card_style: str,
     grayscale_levels: int = 16,
 ) -> tuple[int, int]:
@@ -1150,11 +1150,6 @@ def _build_sensor_rows_context(
         "card_style": card_style,
         "grayscale_levels": grayscale_levels,
         **_metrics_context(m),
-        "m_icon_dia": m.icon_dia,
-        "m_inner_gap": m.inner_gap,
-        "m_font_primary": m.font_primary,
-        "m_font_secondary": m.font_secondary,
-        "m_divider": m.divider,
         "row_h": row_h,
         "rows": rows,
         "lpad": lpad,
@@ -1694,11 +1689,6 @@ def _build_waste_schedule_context(
         "card_style": card_style,
         "grayscale_levels": grayscale_levels,
         **_metrics_context(m),
-        "m_icon_dia": m.icon_dia,
-        "m_inner_gap": m.inner_gap,
-        "m_font_primary": m.font_primary,
-        "m_font_secondary": m.font_secondary,
-        "m_divider": m.divider,
         "row_h": row_h,
         "rows": rows,
         "lpad": lpad,

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -1452,15 +1452,17 @@ def _build_waste_schedule_context(
       using the full widget height; date is shown as a
       ``secondary`` line below the primary label.
 
-    Only entries within the 0–3 day range are rendered.  Entries
-    with missing, unparseable, or out-of-range dates are silently
-    skipped.
+    By default only entries within the 0–3 day range are rendered.
+    When ``show_all`` is ``True``, entries with any future date are
+    included regardless of distance.  Entries with missing,
+    unparseable, or past dates are always silently skipped.
 
     Args:
         widget: Widget config dict.  Recognised keys: ``entity``
             (entity ID whose attributes hold the dates),
             ``entries`` (list of ``{"attribute": …, "label": …}``
             dicts), ``layout`` (``"list"`` or ``"card"``),
+            ``show_all`` (``bool``, default ``False``),
             ``card_style``, ``title``, ``x``, ``y``, ``w``, ``h``.
         config: Display config with ``states`` (entity ID →
             state dict) and ``grayscale_levels``.
@@ -1489,6 +1491,7 @@ def _build_waste_schedule_context(
     layout: str = widget.get("layout", "list")
     card_style = widget.get("card_style", DEFAULT_CARD_STYLE)
     title: str = widget.get("title", "")
+    show_all: bool = bool(widget.get("show_all", False))
     states = config.get("states", {})
     grayscale_levels = config.get("grayscale_levels", 16)
 
@@ -1522,7 +1525,9 @@ def _build_waste_schedule_context(
         if not raw:
             continue
         days = _parse_days_until(raw, today)
-        if days is None or days < 0 or days > 3:
+        if days is None or days < 0:
+            continue
+        if not show_all and days > 3:
             continue
         visible.append((label, raw, days))
 

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextlib
 import functools
 from collections.abc import Callable
+from dataclasses import fields as dc_fields
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -342,8 +343,6 @@ def _metrics_context(m: WidgetMetrics) -> dict[str, object]:
         Dict with ``m_*`` keys for every ``WidgetMetrics`` field,
         ready to unpack into a template context dict.
     """
-    from dataclasses import fields as dc_fields  # noqa: PLC0415
-
     return {f"m_{f.name}": getattr(m, f.name) for f in dc_fields(m)}
 
 
@@ -448,7 +447,7 @@ def _auto_row_height(
 def _row_content_pads(
     m: WidgetMetrics,
     card_style: str,
-    grayscale_levels: int = 16,
+    grayscale_levels: int,
 ) -> tuple[int, int]:
     """Return (lpad, rpad) for a card_row inside a card_container.
 

--- a/custom_components/eink_dashboard/templates/_macros.svg.j2
+++ b/custom_components/eink_dashboard/templates/_macros.svg.j2
@@ -37,19 +37,18 @@
 
 {#
   card_container -- draw card decoration and wrap inner content.
-  Inset logic is mirrored by _card_insets() in svg_render.py.
 
-  Use with Jinja2 {% call %} so the macro body wraps the widget's
-  inner content.  The macro passes back (x_off, right_inset) so the
-  caller can compute the content area: content_x = x + x_off and
-  content_w = w - x_off - right_inset.
+  Purely decorative: emits the border rect or left-bar rect for the
+  chosen card_style, then renders the caller block.  All content
+  positioning is pre-computed in Python via _card_insets(); this
+  macro only draws the chrome.
 
-    {% call(x_off, r_inset) card_container(
+    {% call card_container(
         x=0, y=0, w=400, h=200,
         card_style="border",
-        radius=m.radius, border=m.border,
-        padding=m.padding, left_bar=m.left_bar) %}
-      ... widget content at x_off / r_inset offsets ...
+        radius=m_radius, border=m_border,
+        bar_width=bar_width) %}
+      ... widget content at pre-computed positions ...
     {% endcall %}
 
   Parameters:
@@ -59,16 +58,14 @@
                  values are treated as "none" (no decoration)
     radius    -- corner radius for "border" style
     border    -- stroke width for "border" style
-    padding   -- inner padding returned to caller as x_off / r_inset
-    left_bar  -- bar width for "left_bar" style (before 2-level
-                 widening)
-    grayscale_levels -- display depth; bar widens when <= 2
+    bar_width -- pre-computed bar width for "left_bar" style
+                 (Python is the single source of truth)
 #}
 {%- macro card_container(
     x, y, w, h,
     card_style="none",
-    radius=0, border=2, padding=0,
-    left_bar=0, grayscale_levels=16
+    radius=0, border=2,
+    bar_width=0
 ) -%}
 {%- if card_style == "border" -%}
 {# SVG strokes are centred on the path (half inside, half outside).
@@ -82,20 +79,15 @@
   fill="none"
   stroke="#000000"
   stroke-width="{{ border }}"/>
-{{ caller(padding, padding) }}
+{{ caller() }}
 {%- elif card_style == "left_bar" -%}
-{%- if grayscale_levels <= 2 -%}
-{%- set bar_w = [10, left_bar * 3]|max -%}
-{%- else -%}
-{%- set bar_w = left_bar -%}
-{%- endif -%}
 <rect
   x="{{ x }}" y="{{ y }}"
-  width="{{ bar_w }}" height="{{ h }}"
+  width="{{ bar_width }}" height="{{ h }}"
   fill="#787878"/>
-{{ caller(bar_w + padding, 0) }}
+{{ caller() }}
 {%- else -%}
-{{ caller(0, 0) }}
+{{ caller() }}
 {%- endif -%}
 {%- endmacro -%}
 

--- a/custom_components/eink_dashboard/templates/_macros.svg.j2
+++ b/custom_components/eink_dashboard/templates/_macros.svg.j2
@@ -109,6 +109,8 @@
     primary_fill   -- hex color for primary text
     secondary_fill -- hex color for secondary text
     value_fill     -- hex color for value text
+    lpad      -- left padding override; -1 (default) uses padding
+    rpad      -- right padding override; -1 (default) uses padding
 #}
 {%- macro card_row(
     x, y, w, row_h,
@@ -120,9 +122,12 @@
     letter="",
     primary_fill="#000000",
     secondary_fill="#787878",
-    value_fill="#787878"
+    value_fill="#787878",
+    lpad=-1, rpad=-1
 ) -%}
-{%- set icon_cx = x + padding + icon_dia // 2 -%}
+{%- set lpad = lpad if lpad >= 0 else padding -%}
+{%- set rpad = rpad if rpad >= 0 else padding -%}
+{%- set icon_cx = x + lpad + icon_dia // 2 -%}
 {%- set icon_cy = y + row_h // 2 -%}
 {%- set icon_r = icon_dia // 2 -%}
 {# Icon circle -- outline or solid fill #}
@@ -157,7 +162,7 @@
   dominant-baseline="central"
   fill="{{ lc }}">{{ letter }}</text>
 {%- endif -%}
-{%- set tx = x + padding + icon_dia + inner_gap -%}
+{%- set tx = x + lpad + icon_dia + inner_gap -%}
 {# Text block -- vertically center primary + optional secondary #}
 {%- if secondary -%}
 {# (row_h * 4 + 50) // 100 is integer rounding of row_h * 0.04,
@@ -193,7 +198,7 @@
 {# Right-aligned value text #}
 {%- if value -%}
 <text
-  x="{{ x + w - padding }}" y="{{ y + row_h // 2 }}"
+  x="{{ x + w - rpad }}" y="{{ y + row_h // 2 }}"
   font-family="Roboto"
   font-size="{{ font_secondary }}"
   text-anchor="end"

--- a/custom_components/eink_dashboard/templates/_macros.svg.j2
+++ b/custom_components/eink_dashboard/templates/_macros.svg.j2
@@ -7,8 +7,33 @@
   no layout math happens inside a macro.
 
   Usage:
-    {%- from "_macros.svg.j2" import card_container, card_row, chip -%}
+    {%- from "_macros.svg.j2" import widget_title, card_container,
+        card_row, chip -%}
 #}
+
+{#
+  widget_title -- draw the optional gray title label above a card.
+
+  Emits a single <text> element at (x, 0) with dominant-baseline="hanging"
+  so the title sits flush at the top of the widget viewport.  When title
+  is empty the macro emits nothing.
+
+  Parameters:
+    title     -- title string; empty = no output
+    font_sz   -- font size in pixels
+    x         -- horizontal position (default 0)
+#}
+{%- macro widget_title(title, font_sz, x=0) -%}
+{%- if title -%}
+<text
+  x="{{ x }}" y="0"
+  font-family="Roboto"
+  font-size="{{ font_sz }}"
+  dominant-baseline="hanging"
+  fill="#787878">{{ title }}</text>
+{%- endif -%}
+{%- endmacro -%}
+
 
 {#
   card_container -- draw card decoration and wrap inner content.

--- a/custom_components/eink_dashboard/templates/device_battery.svg.j2
+++ b/custom_components/eink_dashboard/templates/device_battery.svg.j2
@@ -3,13 +3,11 @@
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
 {%- if has_level -%}
-{# xo and ri are unused — absolute positions are pre-computed by the context builder #}
-{%- call(xo, ri) card_container(
+{%- call card_container(
     x=0, y=0, w=w, h=card_h,
     card_style=card_style,
     radius=m_radius, border=m_border,
-    padding=m_padding, left_bar=m_left_bar,
-    grayscale_levels=grayscale_levels) -%}
+    bar_width=bar_width) -%}
 {%- if layout == "chip" -%}
 <rect x="{{ chip_x }}" y="0" width="{{ chip_w }}" height="{{ card_h }}"
   rx="{{ chip_radius }}" ry="{{ chip_radius }}" fill="#ffffff"

--- a/custom_components/eink_dashboard/templates/sensor_rows.svg.j2
+++ b/custom_components/eink_dashboard/templates/sensor_rows.svg.j2
@@ -1,16 +1,10 @@
-{%- from "_macros.svg.j2" import card_container, card_row -%}
+{%- from "_macros.svg.j2" import widget_title, card_container,
+    card_row -%}
 <svg xmlns="http://www.w3.org/2000/svg"
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
 {%- if has_entities -%}
-{%- if title -%}
-<text
-  x="0" y="0"
-  font-family="Roboto"
-  font-size="{{ title_font_sz }}"
-  dominant-baseline="hanging"
-  fill="#787878">{{ title }}</text>
-{%- endif -%}
+{{- widget_title(title, title_font_sz) -}}
 {#- x_off and r_inset are yielded by card_container; lpad/rpad
     come from _row_content_pads() in Python and avoid double-padding
     the icon when a card style is active. -#}

--- a/custom_components/eink_dashboard/templates/sensor_rows.svg.j2
+++ b/custom_components/eink_dashboard/templates/sensor_rows.svg.j2
@@ -11,11 +11,9 @@
   dominant-baseline="hanging"
   fill="#787878">{{ title }}</text>
 {%- endif -%}
-{#- x_off and r_inset are yielded by the card_container macro and
-    depend on card_style — they cannot be pre-computed in Python
-    without duplicating the macro's inset logic.  The arithmetic
-    expressions below are the only deliberate exception to the
-    "no layout logic in templates" rule. -#}
+{#- x_off and r_inset are yielded by card_container; lpad/rpad
+    come from _row_content_pads() in Python and avoid double-padding
+    the icon when a card style is active. -#}
 {%- call(x_off, r_inset) card_container(
     x=0, y=content_y, w=w, h=content_h,
     card_style=card_style,
@@ -36,12 +34,13 @@
     primary=row.primary,
     secondary=row.secondary,
     icon_svg=row.icon_svg,
-    letter=row.letter) }}
+    letter=row.letter,
+    lpad=lpad, rpad=rpad) }}
 {%- if not loop.last -%}
 <line
-  x1="{{ x_off + m_padding }}"
+  x1="{{ x_off + lpad }}"
   y1="{{ row.y + row_h }}"
-  x2="{{ w - r_inset - m_padding }}"
+  x2="{{ w - r_inset - rpad }}"
   y2="{{ row.y + row_h }}"
   stroke="#787878"
   stroke-width="{{ m_divider }}"/>

--- a/custom_components/eink_dashboard/templates/sensor_rows.svg.j2
+++ b/custom_components/eink_dashboard/templates/sensor_rows.svg.j2
@@ -4,20 +4,13 @@
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
 {%- if has_entities -%}
-{{- widget_title(title, title_font_sz) -}}
-{#- x_off and r_inset are yielded by card_container; lpad/rpad
-    come from _row_content_pads() in Python and avoid double-padding
-    the icon when a card style is active. -#}
-{%- call(x_off, r_inset) card_container(
+{{ widget_title(title, title_font_sz) }}
+{%- call card_container(
     x=0, y=content_y, w=w, h=content_h,
     card_style=card_style,
     radius=m_radius, border=m_border,
-    padding=m_padding, left_bar=m_left_bar,
-    grayscale_levels=grayscale_levels) -%}
+    bar_width=bar_width) -%}
 {%- for row in rows -%}
-{#- row.y is an absolute SVG coordinate pre-computed in Python.
-    card_container emits plain SVG elements without a <g transform>,
-    so absolute coordinates are correct inside this caller block. -#}
 {{ card_row(
     x=x_off, y=row.y,
     w=w - x_off - r_inset, row_h=row_h,

--- a/custom_components/eink_dashboard/templates/status_icons.svg.j2
+++ b/custom_components/eink_dashboard/templates/status_icons.svg.j2
@@ -4,17 +4,12 @@
      width="{{ w }}" height="{{ total_h }}">
 <rect width="{{ w }}" height="{{ total_h }}" fill="white"/>
 {%- if has_entities -%}
-{{- widget_title(title, title_font_sz) -}}
-{# xo and ri unused — chip positions are pre-computed by the
-   context builder with card container insets already applied.
-   h=total_h-title_advance so the decoration covers all chip
-   rows when wrapping occurs. #}
-{%- call(xo, ri) card_container(
+{{ widget_title(title, title_font_sz) }}
+{%- call card_container(
     x=0, y=title_advance, w=w, h=total_h - title_advance,
     card_style=card_style,
     radius=m_radius, border=m_border,
-    padding=m_padding, left_bar=m_left_bar,
-    grayscale_levels=grayscale_levels) -%}
+    bar_width=bar_width) -%}
 {%- for c in chips -%}
 {{ chip(
     x=c.x, y=c.y, w=c.w, h=chip_h,

--- a/custom_components/eink_dashboard/templates/status_icons.svg.j2
+++ b/custom_components/eink_dashboard/templates/status_icons.svg.j2
@@ -1,16 +1,10 @@
-{%- from "_macros.svg.j2" import card_container, chip -%}
+{%- from "_macros.svg.j2" import widget_title, card_container,
+    chip -%}
 <svg xmlns="http://www.w3.org/2000/svg"
      width="{{ w }}" height="{{ total_h }}">
 <rect width="{{ w }}" height="{{ total_h }}" fill="white"/>
 {%- if has_entities -%}
-{%- if title -%}
-<text
-  x="0" y="0"
-  font-family="Roboto"
-  font-size="{{ title_font_sz }}"
-  dominant-baseline="hanging"
-  fill="#787878">{{ title }}</text>
-{%- endif -%}
+{{- widget_title(title, title_font_sz) -}}
 {# xo and ri unused — chip positions are pre-computed by the
    context builder with card container insets already applied.
    h=total_h-title_advance so the decoration covers all chip

--- a/custom_components/eink_dashboard/templates/text.svg.j2
+++ b/custom_components/eink_dashboard/templates/text.svg.j2
@@ -1,15 +1,8 @@
-{%- from "_macros.svg.j2" import card_container -%}
+{%- from "_macros.svg.j2" import widget_title, card_container -%}
 <svg xmlns="http://www.w3.org/2000/svg"
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
-{%- if title -%}
-<text
-  x="{{ title_x }}" y="0"
-  font-family="Roboto"
-  font-size="{{ title_font_sz }}"
-  dominant-baseline="hanging"
-  fill="#787878">{{ title }}</text>
-{%- endif -%}
+{{- widget_title(title, title_font_sz, x=title_x) -}}
 {# xo and ri are unused — absolute positions are pre-computed by the context builder #}
 {%- call(xo, ri) card_container(
     x=0, y=content_y, w=w, h=content_h,

--- a/custom_components/eink_dashboard/templates/text.svg.j2
+++ b/custom_components/eink_dashboard/templates/text.svg.j2
@@ -2,14 +2,14 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
-{{- widget_title(title, title_font_sz, x=title_x) -}}
-{# xo and ri are unused — absolute positions are pre-computed by the context builder #}
-{%- call(xo, ri) card_container(
+{%- if title -%}
+{{ widget_title(title, title_font_sz, x=title_x) }}
+{%- endif -%}
+{%- call card_container(
     x=0, y=content_y, w=w, h=content_h,
     card_style=card_style,
     radius=m_radius, border=m_border,
-    padding=m_padding, left_bar=m_left_bar,
-    grayscale_levels=grayscale_levels) -%}
+    bar_width=bar_width) -%}
 <text x="{{ text_x }}" y="{{ text_y }}"
   font-family="Roboto"
   font-size="{{ font_size }}"

--- a/custom_components/eink_dashboard/templates/waste_schedule.svg.j2
+++ b/custom_components/eink_dashboard/templates/waste_schedule.svg.j2
@@ -4,20 +4,13 @@
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
 {%- if has_rows -%}
-{{- widget_title(title, title_font_sz) -}}
-{#- x_off and r_inset are yielded by card_container; lpad/rpad
-    come from _row_content_pads() in Python and avoid double-padding
-    the icon when a card style is active. -#}
-{%- call(x_off, r_inset) card_container(
+{{ widget_title(title, title_font_sz) }}
+{%- call card_container(
     x=0, y=content_y, w=w, h=content_h,
     card_style=card_style,
     radius=m_radius, border=m_border,
-    padding=m_padding, left_bar=m_left_bar,
-    grayscale_levels=grayscale_levels) -%}
+    bar_width=bar_width) -%}
 {%- for row in rows -%}
-{#- row.y is an absolute SVG coordinate pre-computed in Python.
-    card_container emits plain SVG elements without a <g transform>,
-    so absolute coordinates are correct inside this caller block. -#}
 {{ card_row(
     x=x_off, y=row.y,
     w=w - x_off - r_inset, row_h=row_h,

--- a/custom_components/eink_dashboard/templates/waste_schedule.svg.j2
+++ b/custom_components/eink_dashboard/templates/waste_schedule.svg.j2
@@ -1,16 +1,10 @@
-{%- from "_macros.svg.j2" import card_container, card_row -%}
+{%- from "_macros.svg.j2" import widget_title, card_container,
+    card_row -%}
 <svg xmlns="http://www.w3.org/2000/svg"
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
 {%- if has_rows -%}
-{%- if title -%}
-<text
-  x="0" y="0"
-  font-family="Roboto"
-  font-size="{{ title_font_sz }}"
-  dominant-baseline="hanging"
-  fill="#787878">{{ title }}</text>
-{%- endif -%}
+{{- widget_title(title, title_font_sz) -}}
 {#- x_off and r_inset are yielded by card_container; lpad/rpad
     come from _row_content_pads() in Python and avoid double-padding
     the icon when a card style is active. -#}

--- a/custom_components/eink_dashboard/templates/waste_schedule.svg.j2
+++ b/custom_components/eink_dashboard/templates/waste_schedule.svg.j2
@@ -11,11 +11,9 @@
   dominant-baseline="hanging"
   fill="#787878">{{ title }}</text>
 {%- endif -%}
-{#- x_off and r_inset are yielded by the card_container macro and
-    depend on card_style — they cannot be pre-computed in Python
-    without duplicating the macro's inset logic.  The arithmetic
-    expressions below are the only deliberate exception to the
-    "no layout logic in templates" rule. -#}
+{#- x_off and r_inset are yielded by card_container; lpad/rpad
+    come from _row_content_pads() in Python and avoid double-padding
+    the icon when a card style is active. -#}
 {%- call(x_off, r_inset) card_container(
     x=0, y=content_y, w=w, h=content_h,
     card_style=card_style,
@@ -41,12 +39,13 @@
     icon_outline=row.icon_outline,
     value_fill=row.value_fill,
     secondary_fill=row.secondary_fill,
-    letter=row.letter) }}
+    letter=row.letter,
+    lpad=lpad, rpad=rpad) }}
 {%- if not loop.last -%}
 <line
-  x1="{{ x_off + m_padding }}"
+  x1="{{ x_off + lpad }}"
   y1="{{ row.y + row_h }}"
-  x2="{{ w - r_inset - m_padding }}"
+  x2="{{ w - r_inset - rpad }}"
   y2="{{ row.y + row_h }}"
   stroke="#787878"
   stroke-width="{{ m_divider }}"/>

--- a/custom_components/eink_dashboard/templates/weather.svg.j2
+++ b/custom_components/eink_dashboard/templates/weather.svg.j2
@@ -3,13 +3,11 @@
      width="{{ w }}" height="{{ h }}">
 <rect width="{{ w }}" height="{{ h }}" fill="white"/>
 {%- if has_state -%}
-{# xo and ri are unused — absolute positions are pre-computed by the context builder #}
-{%- call(xo, ri) card_container(
+{%- call card_container(
     x=0, y=0, w=card_w, h=total_h,
     card_style=card_style,
     radius=m_radius, border=m_border,
-    padding=m_padding, left_bar=m_left_bar,
-    grayscale_levels=grayscale_levels) -%}
+    bar_width=bar_width) -%}
 {# Row 1: condition icon, temperature, today hi/lo/precip. #}
 {%- if icon_svg -%}
 <g transform="translate({{ icon_x }}, {{ icon_y }})">{{ icon_svg }}</g>

--- a/docs/waste_schedule.md
+++ b/docs/waste_schedule.md
@@ -1,0 +1,78 @@
+# Waste Schedule Widget
+
+The **Waste Schedule** widget displays upcoming collection dates read from
+the [Waste Collection Schedule](https://github.com/mampfes/hacs_waste_collection_schedule)
+integration (available via HACS).
+
+The widget shows entries whose next collection falls within the next three
+days (today, tomorrow, in 2 days, in 3 days). Entries further in the future
+are hidden until they enter that window.
+
+## 1. Install and configure the integration
+
+Install **Waste Collection Schedule** via HACS, then go to
+**Settings → Devices & Services → Add Integration** and search for
+**Waste Collection Schedule**. Follow the wizard to select your country,
+service provider, and address details.
+
+## 2. Add a sensor with `appointment_types` format
+
+After the integration is set up, you need a sensor configured with the
+`appointment_types` details format. To add one:
+
+1. Go to **Settings → Devices & Services → Waste Collection Schedule →
+   Configure**.
+2. Under **Sensors To Modify**, select **Add new sensor**.
+3. On the next page, set **Details Format** to **`appointment_types`** and
+   give the sensor a name (e.g. `Waste Schedule`).
+4. Save.
+
+With this format each attribute of the sensor represents one waste type and
+its value is the ISO date of the next scheduled collection:
+
+```
+Organic Waste  →  2026-05-17
+Paper          →  2026-05-22
+Recycling      →  2026-05-20
+```
+
+The other formats (`upcoming`, `generic`) produce a different data shape
+that the widget cannot read — `appointment_types` is required.
+
+### YAML configuration (alternative)
+
+If you prefer YAML instead of the config flow, add to `configuration.yaml`:
+
+```yaml
+waste_collection_schedule:
+  sources:
+    - name: your_provider   # see the integration docs for provider names
+      args:
+        # provider-specific address fields go here
+  sensors:
+    - name: "Waste Schedule"
+      details_format: appointment_types
+```
+
+Restart Home Assistant. The resulting entity ID will be
+`sensor.waste_schedule` (lower-cased from the sensor name).
+
+## 3. Add the widget
+
+In the dashboard editor, add a **Waste Schedule** widget and configure it:
+
+| Field | Value |
+|---|---|
+| Entity | The `sensor.*` entity created above |
+| Entries | One entry per waste type you want to show |
+
+For each entry:
+
+| Field | Value |
+|---|---|
+| Attribute | Attribute name on the sensor (e.g. `Organic Waste`) — must match exactly |
+| Label | Short label shown on the display (e.g. `Organic`) |
+
+By default the widget only shows entries whose next collection is within the
+next three days. Enable **Show all upcoming dates** to display every
+configured waste type regardless of how far away the next collection is.

--- a/scripts/bench_render.py
+++ b/scripts/bench_render.py
@@ -5,11 +5,10 @@ Measures per-stage timings for the SVG pipeline.
 Runs without a Home Assistant installation.
 
 Stages measured:
-  svg_render   -- per-widget Jinja2 context build + template render
-  svg_compose  -- _compose_svg() nesting all widgets into one root SVG
-  svg_rasterise -- resvg rasterisation (_svg_to_png())
+  svg_render    -- per-widget Jinja2 context build + template render
+  svg_rasterise -- per-widget resvg rasterisation + PIL paste
   eink_optimize -- optimize_for_eink() dithering / quantisation
-  end_to_end   -- full wall-clock time including PNG encode
+  end_to_end    -- full wall-clock time including PNG encode
 
 Usage:
     python3 scripts/bench_render.py
@@ -30,8 +29,9 @@ Usage:
 # Peak RSS: 36.3 MB
 # ---------------------------------------------------------------------------
 #
-# SVG baseline (kindle_pw, 758x1024, 16-level, optimize=True)
+# SVG composed baseline (kindle_pw, 758x1024, 16-level, optimize=True)
 # Recorded after SVG migration (step 2.1).  All 7 widgets, 20 iterations.
+# Used _compose_svg() + single resvg call for the full dashboard.
 #
 # Stage              min    median     p95     max  (ms)
 # svg_render        1.11      1.22    1.36    1.38
@@ -41,6 +41,19 @@ Usage:
 # end_to_end      143.14    144.40  146.98  148.16
 #
 # Peak RSS: 48.6 MB
+# ---------------------------------------------------------------------------
+#
+# SVG per-widget (kindle_pw, 758x1024, 16-level, optimize=True)
+# Per-widget resvg rasterisation + PIL paste.  All 7 widgets, 30
+# iterations.  ~3.4x faster end-to-end vs composed baseline.
+#
+# Stage              min    median     p95     max  (ms)
+# svg_render        1.28      1.36    1.47    1.47
+# svg_rasterise    19.21     19.54   20.13   20.79
+# eink_optimize    14.79     15.18   15.96   17.22
+# end_to_end       37.81     38.55   40.48   42.26
+#
+# Peak RSS: 45.6 MB
 # ---------------------------------------------------------------------------
 """
 
@@ -77,7 +90,6 @@ from custom_components.eink_dashboard.optimize import (  # noqa: E402
 )
 from custom_components.eink_dashboard.svg_render import (  # noqa: E402
     _SVG_RENDERERS,
-    _compose_svg,
     _svg_to_png,
     render_widget_svg,
 )
@@ -382,11 +394,10 @@ def _bench(
     """Benchmark the SVG rendering pipeline with per-stage timing.
 
     Decomposes the SVG pipeline into four timed stages: per-widget
-    Jinja2 rendering, SVG composition, resvg rasterisation, and
-    e-ink optimisation.  PNG encoding is not a separate stage but
-    is included in the end_to_end wall-clock measurement.  Runs
-    ``n`` timed iterations; call once before this function for a
-    warmup to populate font/icon LRU caches.
+    Jinja2 rendering, per-widget resvg rasterisation + PIL paste,
+    e-ink optimisation, and PNG encoding.  Runs ``n`` timed
+    iterations; call once before this function for a warmup to
+    populate font/icon LRU caches.
 
     Args:
         widgets: Widget config dicts to render.
@@ -394,21 +405,16 @@ def _bench(
         n: Number of measured iterations.
 
     Returns:
-        List of six ``_BenchResult`` objects for stages
-        ``svg_render``, ``svg_compose``, ``svg_rasterise``,
-        ``per_widget_rasterise``, ``eink_optimize``, and
-        ``end_to_end``.  ``per_widget_rasterise`` times N separate
-        resvg calls (one per widget) so it can be compared directly
-        against the single-call ``svg_rasterise`` stage.
+        List of four ``_BenchResult`` objects for stages
+        ``svg_render``, ``svg_rasterise``, ``eink_optimize``,
+        and ``end_to_end``.
     """
     config = {"width": 600, "height": 800, **config}
     w = config["width"]
     h = config["height"]
 
     stage_svgrender = _BenchResult("svg_render")
-    stage_compose = _BenchResult("svg_compose")
     stage_rasterise = _BenchResult("svg_rasterise")
-    stage_per_widget = _BenchResult("per_widget_rasterise")
     stage_opt = _BenchResult("eink_optimize")
     stage_e2e = _BenchResult("end_to_end")
 
@@ -419,7 +425,6 @@ def _bench(
         t0 = time.perf_counter_ns()
         svg_parts: list[str] = []
         positions: list[tuple[int, int]] = []
-        widths: list[int] = []
         for widget in widgets:
             wtype = widget.get("type")
             if wtype not in _SVG_RENDERERS:
@@ -427,35 +432,23 @@ def _bench(
             wx = widget.get("x", PADDING)
             svg_parts.append(render_widget_svg(widget, config))
             positions.append((wx, widget.get("y", 0)))
-            widths.append(widget.get("w", w - wx))
         stage_svgrender.times_ns.append(time.perf_counter_ns() - t0)
 
-        # Stage 2: compose all widget SVGs into one root document.
+        # Stage 2: per-widget resvg rasterisation + PIL paste.
         t0 = time.perf_counter_ns()
-        composed = _compose_svg(svg_parts, positions, w, h)
-        stage_compose.times_ns.append(time.perf_counter_ns() - t0)
-
-        # Stage 3a: single resvg call for the composed dashboard.
-        t0 = time.perf_counter_ns()
-        png = _svg_to_png(composed, w, h)
+        img = Image.new("L", (w, h), 255)
+        for svg, (wx, wy) in zip(svg_parts, positions, strict=True):
+            png = _svg_to_png(svg)
+            wimg = Image.open(io.BytesIO(png)).convert("L")
+            img.paste(wimg, (wx, wy))
         stage_rasterise.times_ns.append(time.perf_counter_ns() - t0)
-
-        # Stage 3b: N separate resvg calls, one per widget.  Mirrors
-        # the pre-2.1 per-widget approach so both strategies can be
-        # compared directly.  Output is discarded; only time matters.
-        t0 = time.perf_counter_ns()
-        for svg, sw in zip(svg_parts, widths, strict=True):
-            _svg_to_png(svg, sw)
-        stage_per_widget.times_ns.append(time.perf_counter_ns() - t0)
-
-        img = Image.open(io.BytesIO(png)).convert("L")
 
         # Rotation (default presets have rotation=0, so no-op).
         rotation = config.get("rotation", 0)
         if rotation:
             img = img.rotate(rotation, expand=True)
 
-        # Stage 4: e-ink optimisation (dithering / quantisation).
+        # Stage 3: e-ink optimisation (dithering / quantisation).
         t0 = time.perf_counter_ns()
         img = optimize_for_eink(img, config)
         stage_opt.times_ns.append(time.perf_counter_ns() - t0)
@@ -469,9 +462,7 @@ def _bench(
 
     return [
         stage_svgrender,
-        stage_compose,
         stage_rasterise,
-        stage_per_widget,
         stage_opt,
         stage_e2e,
     ]

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+import re
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,10 @@ from custom_components.eink_dashboard.render import (
     _load_font,
     _parse_days_until,
     render_dashboard,
+)
+from custom_components.eink_dashboard.svg_render import (
+    _DEFAULT_ROW_H,
+    render_widget_svg,
 )
 from tests.helpers import (
     assert_all_white,
@@ -1505,6 +1510,56 @@ class TestRenderSensorRows:
             56,
             threshold=200,
         )
+
+    # ── Auto-sizing tests ─────────────────────────────
+
+    def test_sensor_rows_auto_height_single_entity(self) -> None:
+        # Without explicit h, widget height equals _DEFAULT_ROW_H.
+        w = {
+            "type": "sensor_rows",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "entities": ["sensor.living_room_temperature"],
+        }
+        svg = render_widget_svg(w, self._config())
+        # Parse height from the SVG viewport attribute.
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == _DEFAULT_ROW_H
+
+    def test_sensor_rows_auto_height_two_entities(self) -> None:
+        # Without explicit h, widget height equals 2 * _DEFAULT_ROW_H.
+        w = {
+            "type": "sensor_rows",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "entities": [
+                "sensor.living_room_temperature",
+                "sensor.living_room_temperature",
+            ],
+        }
+        svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == 2 * _DEFAULT_ROW_H
+
+    def test_sensor_rows_explicit_h_preserved(self) -> None:
+        # An explicit h overrides auto-sizing.
+        explicit_h = 200
+        w = {
+            "type": "sensor_rows",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": explicit_h,
+            "entities": ["sensor.living_room_temperature"],
+        }
+        svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == explicit_h
 
 
 class TestRenderDeviceBattery:
@@ -3159,6 +3214,55 @@ class TestRenderWasteSchedule:
         icon_h = icon_bb[3] - icon_bb[1]
         # Icon should span at least 40% of widget height
         assert icon_h > h * 0.4
+
+    # ── Auto-sizing tests ─────────────────────────────
+
+    def test_waste_schedule_auto_height_single_entry(self) -> None:
+        # Without explicit h, widget height equals _DEFAULT_ROW_H.
+        w = {
+            "type": "waste_schedule",
+            "entity": "sensor.waste_collection",
+            "entries": [{"attribute": "Restmuell", "label": "Restmuell"}],
+            "x": 0,
+            "y": 0,
+            "w": 400,
+        }
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == _DEFAULT_ROW_H
+
+    def test_waste_schedule_auto_height_three_entries(self) -> None:
+        # Without explicit h, widget height equals 3 * _DEFAULT_ROW_H.
+        # Relies on all three _ENTRIES attributes being present and
+        # within 0–3 days in MOCK_WASTE_SCHEDULE_STATES on _TODAY.
+        w = {
+            "type": "waste_schedule",
+            "entity": "sensor.waste_collection",
+            "entries": list(self._ENTRIES),
+            "x": 0,
+            "y": 0,
+            "w": 400,
+        }
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == 3 * _DEFAULT_ROW_H
+
+    def test_waste_schedule_explicit_h_preserved(self) -> None:
+        # An explicit h overrides auto-sizing.
+        explicit_h = 300
+        w = self._widget(h=explicit_h)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == explicit_h
 
 
 class TestFontSizeControls:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -25,7 +25,6 @@ from custom_components.eink_dashboard.svg_render import (
     _auto_row_height,
     _card_insets,
     _metrics_context,
-    _row_content_pads,
     _title_layout,
     render_widget_svg,
 )
@@ -3483,6 +3482,7 @@ class TestHelperFunctions:
         assert _card_insets(m, "border", 16) == (
             m.padding,
             m.padding,
+            0,
         )
 
     def test_card_insets_left_bar(self) -> None:
@@ -3491,24 +3491,23 @@ class TestHelperFunctions:
         assert _card_insets(m, "left_bar", 16) == (
             m.left_bar + m.padding,
             0,
+            m.left_bar,
         )
 
     def test_card_insets_left_bar_2level(self) -> None:
-        """2-level display widens the bar via max(10, left_bar*3).
-
-        Mirrors the Jinja2 macro: ``[10, left_bar * 3]|max``.
-        """
+        """2-level display widens the bar via max(10, left_bar*3)."""
         m = _compute_metrics(56)
         bar_w = max(10, m.left_bar * 3)
         assert _card_insets(m, "left_bar", 2) == (
             bar_w + m.padding,
             0,
+            bar_w,
         )
 
     def test_card_insets_none(self) -> None:
         """No card style produces zero insets."""
         m = _compute_metrics(56)
-        assert _card_insets(m, "none", 16) == (0, 0)
+        assert _card_insets(m, "none", 16) == (0, 0, 0)
 
     def test_auto_row_height_no_title(self) -> None:
         """Without title, height is num_rows * _DEFAULT_ROW_H."""
@@ -3524,24 +3523,3 @@ class TestHelperFunctions:
         """num_rows < 1 raises ValueError."""
         with pytest.raises(ValueError, match="num_rows"):
             _auto_row_height("", 0)
-
-    def test_row_content_pads_border(self) -> None:
-        """Border container provides both insets; row adds none."""
-        m = _compute_metrics(56)
-        assert _row_content_pads(m, "border", 16) == (0, 0)
-
-    def test_row_content_pads_left_bar(self) -> None:
-        """Left-bar container provides left inset; row adds right."""
-        m = _compute_metrics(56)
-        assert _row_content_pads(m, "left_bar", 16) == (
-            0,
-            m.padding,
-        )
-
-    def test_row_content_pads_none(self) -> None:
-        """No container insets; row provides padding on both sides."""
-        m = _compute_metrics(56)
-        assert _row_content_pads(m, "none", 16) == (
-            m.padding,
-            m.padding,
-        )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3042,6 +3042,49 @@ class TestRenderWasteSchedule:
             img = render_to_image([w], self._config(states=states))
         assert_all_white(img, 0, 0, 400, 300)
 
+    def test_show_all_renders_far_entry(self) -> None:
+        # With show_all=True, entries beyond 3 days are rendered.
+        states = {
+            "sensor.waste_collection": {
+                "state": "far",
+                "attributes": {
+                    "friendly_name": "Waste",
+                    "Restmuell": "2026-05-09",
+                },
+            },
+        }
+        entries = [
+            {"attribute": "Restmuell", "label": "Restmuell"},
+        ]
+        # 2026-05-09 is 7 days from 2026-05-02 → normally filtered
+        w = self._widget(entries=entries, h=56, show_all=True)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config(states=states))
+        assert_has_dark_pixels(img, 0, 0, 400, 56, threshold=200)
+
+    def test_show_all_false_keeps_default_cutoff(self) -> None:
+        # With show_all=False (or omitted), entries beyond 3 days
+        # are still filtered and the widget renders blank.
+        states = {
+            "sensor.waste_collection": {
+                "state": "far",
+                "attributes": {
+                    "friendly_name": "Waste",
+                    "Restmuell": "2026-05-09",
+                },
+            },
+        }
+        entries = [
+            {"attribute": "Restmuell", "label": "Restmuell"},
+        ]
+        # 2026-05-09 is 7 days from 2026-05-02 → filtered
+        w = self._widget(entries=entries, h=56, show_all=False)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config(states=states))
+        assert_all_white(img, 0, 0, 400, 300)
+
     def test_integer_attribute_value(self) -> None:
         # Integer strings in attributes parse correctly.
         states = {

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -22,6 +22,11 @@ from custom_components.eink_dashboard.render import (
 )
 from custom_components.eink_dashboard.svg_render import (
     _DEFAULT_ROW_H,
+    _auto_row_height,
+    _card_insets,
+    _metrics_context,
+    _row_content_pads,
+    _title_layout,
     render_widget_svg,
 )
 from tests.helpers import (
@@ -3461,3 +3466,82 @@ class TestComputeMetrics:
         m = _compute_metrics(56)
         for f in dataclasses.fields(WidgetMetrics):
             assert isinstance(getattr(m, f.name), int), f"{f.name} is not int"
+
+
+class TestHelperFunctions:
+    """Unit tests for shared helpers in svg_render.py."""
+
+    def test_metrics_context_keys(self) -> None:
+        """All keys are m_-prefixed and include baseline values."""
+        ctx = _metrics_context(_compute_metrics(56))
+        assert all(k.startswith("m_") for k in ctx)
+        assert ctx["m_padding"] == 12
+
+    def test_card_insets_border(self) -> None:
+        """Border style insets padding on both sides."""
+        m = _compute_metrics(56)
+        assert _card_insets(m, "border", 16) == (
+            m.padding,
+            m.padding,
+        )
+
+    def test_card_insets_left_bar(self) -> None:
+        """Left-bar style insets bar_w + padding on the left."""
+        m = _compute_metrics(56)
+        assert _card_insets(m, "left_bar", 16) == (
+            m.left_bar + m.padding,
+            0,
+        )
+
+    def test_card_insets_left_bar_2level(self) -> None:
+        """2-level display widens the bar via max(10, left_bar*3).
+
+        Mirrors the Jinja2 macro: ``[10, left_bar * 3]|max``.
+        """
+        m = _compute_metrics(56)
+        bar_w = max(10, m.left_bar * 3)
+        assert _card_insets(m, "left_bar", 2) == (
+            bar_w + m.padding,
+            0,
+        )
+
+    def test_card_insets_none(self) -> None:
+        """No card style produces zero insets."""
+        m = _compute_metrics(56)
+        assert _card_insets(m, "none", 16) == (0, 0)
+
+    def test_auto_row_height_no_title(self) -> None:
+        """Without title, height is num_rows * _DEFAULT_ROW_H."""
+        assert _auto_row_height("", 2) == 2 * _DEFAULT_ROW_H
+
+    def test_auto_row_height_with_title(self) -> None:
+        """With title, content_h matches target within 1 px."""
+        h = _auto_row_height("Title", 2)
+        _, _, content_h = _title_layout("Title", h)
+        assert abs(content_h - 2 * _DEFAULT_ROW_H) <= 1
+
+    def test_auto_row_height_rejects_zero_rows(self) -> None:
+        """num_rows < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="num_rows"):
+            _auto_row_height("", 0)
+
+    def test_row_content_pads_border(self) -> None:
+        """Border container provides both insets; row adds none."""
+        m = _compute_metrics(56)
+        assert _row_content_pads(m, "border", 16) == (0, 0)
+
+    def test_row_content_pads_left_bar(self) -> None:
+        """Left-bar container provides left inset; row adds right."""
+        m = _compute_metrics(56)
+        assert _row_content_pads(m, "left_bar", 16) == (
+            0,
+            m.padding,
+        )
+
+    def test_row_content_pads_none(self) -> None:
+        """No container insets; row provides padding on both sides."""
+        m = _compute_metrics(56)
+        assert _row_content_pads(m, "none", 16) == (
+            m.padding,
+            m.padding,
+        )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1561,6 +1561,60 @@ class TestRenderSensorRows:
         assert m is not None
         assert int(m.group(1)) == explicit_h
 
+    def test_sensor_rows_border_single_padding(self) -> None:
+        # With card_style="border", card_container yields x_off=padding
+        # so card_row must not add its own padding again.  The icon
+        # circle left arc should appear in the strip m.padding..2*m.padding;
+        # double-padding would push the circle entirely past 2*m.padding.
+        metrics = _compute_metrics(_DEFAULT_ROW_H)
+        widgets = [
+            {
+                "type": "sensor_rows",
+                "x": 0,
+                "y": 0,
+                "w": 400,
+                "card_style": "border",
+                "entities": ["sensor.living_room_temperature"],
+            }
+        ]
+        img = render_to_image(widgets, self._config())
+        assert_has_dark_pixels(
+            img,
+            metrics.padding,
+            0,
+            2 * metrics.padding,
+            _DEFAULT_ROW_H,
+            threshold=200,
+        )
+
+    def test_sensor_rows_left_bar_single_padding(self) -> None:
+        # With card_style="left_bar", card_container yields
+        # x_off = bar_w + m.padding.  The icon circle left arc should
+        # appear in the strip (bar_w+m.padding)..(bar_w+2*m.padding);
+        # double-padding would push it entirely past bar_w+2*m.padding.
+        metrics = _compute_metrics(_DEFAULT_ROW_H)
+        # For grayscale_levels=16 (default), bar_w == m.left_bar.
+        bar_w = metrics.left_bar
+        widgets = [
+            {
+                "type": "sensor_rows",
+                "x": 0,
+                "y": 0,
+                "w": 400,
+                "card_style": "left_bar",
+                "entities": ["sensor.living_room_temperature"],
+            }
+        ]
+        img = render_to_image(widgets, self._config())
+        assert_has_dark_pixels(
+            img,
+            bar_w + metrics.padding,
+            0,
+            bar_w + 2 * metrics.padding,
+            _DEFAULT_ROW_H,
+            threshold=200,
+        )
+
 
 class TestRenderDeviceBattery:
     # Verify rendering of device battery widgets in both icon and chip
@@ -2781,6 +2835,28 @@ class TestRenderWasteSchedule:
             img = render_to_image([w], self._config())
         # Area just below the row must be white
         assert_all_white(img, 0, 57, 400, 60)
+
+    def test_waste_schedule_border_single_padding(self) -> None:
+        # With card_style="border", card_container yields x_off=padding
+        # so card_row must not add its own padding again.  The icon
+        # circle left arc should appear in the strip m.padding..2*m.padding;
+        # double-padding would push it entirely past 2*m.padding.
+        entries = [{"attribute": "Restmuell", "label": "Restmuell"}]
+        w = self._widget(
+            entries=entries, h=_DEFAULT_ROW_H, card_style="border"
+        )
+        metrics = _compute_metrics(_DEFAULT_ROW_H)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_has_dark_pixels(
+            img,
+            metrics.padding,
+            0,
+            2 * metrics.padding,
+            _DEFAULT_ROW_H,
+            threshold=200,
+        )
 
     # ── Alignment tests ───────────────────────────────
 

--- a/tests/test_svg_render.py
+++ b/tests/test_svg_render.py
@@ -178,10 +178,10 @@ def test_card_container_border_draws_rounded_rect(render_macro) -> None:
     img = render_macro(
         "{%- from '_macros.svg.j2' import card_container -%}"
         + _SVG_OPEN
-        + "{% call(xo, ri) card_container("
+        + "{% call card_container("
         "x=10, y=10, w=380, h=180,"
         " card_style='border',"
-        " radius=12, border=3, padding=12) %}"
+        " radius=12, border=3) %}"
         "{% endcall %}" + _SVG_CLOSE
     )
     # Top border: dark pixels across the middle of the top edge
@@ -204,10 +204,10 @@ def test_card_container_left_bar_draws_gray(render_macro) -> None:
     img = render_macro(
         "{%- from '_macros.svg.j2' import card_container -%}"
         + _SVG_OPEN
-        + "{% call(xo, ri) card_container("
+        + "{% call card_container("
         "x=10, y=10, w=380, h=180,"
         " card_style='left_bar',"
-        " left_bar=6, padding=10) %}"
+        " bar_width=6) %}"
         "{% endcall %}" + _SVG_CLOSE
     )
     # Gray bar in the left_bar area (x=10..16, middle of height)
@@ -217,22 +217,23 @@ def test_card_container_left_bar_draws_gray(render_macro) -> None:
     assert_all_white(img, 20, 10, 390, 190)
 
 
-def test_card_container_left_bar_widens_for_2_level(render_macro) -> None:
-    """Verify left_bar widens to max(10, left_bar*3) on 2-level displays."""
-    # left_bar=4 → bar_w = max(10, 4*3) = 12
+def test_card_container_left_bar_precomputed_width(
+    render_macro,
+) -> None:
+    """Verify left_bar renders at the pre-computed bar_width."""
+    # bar_width=12 (pre-computed by Python, e.g. max(10, 4*3))
     img = render_macro(
         "{%- from '_macros.svg.j2' import card_container -%}"
         + _SVG_OPEN
-        + "{% call(xo, ri) card_container("
+        + "{% call card_container("
         "x=10, y=10, w=380, h=180,"
         " card_style='left_bar',"
-        " left_bar=4, padding=8, grayscale_levels=2) %}"
+        " bar_width=12) %}"
         "{% endcall %}" + _SVG_CLOSE
     )
-    # Widened bar covers x=10..22 (10 + 12); check near the right
-    # edge of the widened bar.
+    # Bar covers x=10..22 (10 + 12); check near the right edge.
     assert_has_gray_pixels(img, 10, 50, 22, 150)
-    # Area well past the widened bar should be white
+    # Area well past the bar should be white
     assert_all_white(img, 35, 10, 390, 190)
 
 
@@ -246,7 +247,7 @@ def test_card_container_none_caller_invoked(render_macro) -> None:
     img = render_macro(
         "{%- from '_macros.svg.j2' import card_container -%}"
         + _SVG_OPEN
-        + "{% call(xo, ri) card_container("
+        + "{% call card_container("
         "x=10, y=10, w=380, h=180, card_style='none') %}"
         "<rect x='150' y='90' width='30' height='20' fill='black'/>"
         "{% endcall %}" + _SVG_CLOSE


### PR DESCRIPTION
```
./scripts/bench_render.py        

============================================================
  kindle_pw (758x1024, 16-level) | all widgets | 20 iter
============================================================

Stage                  min  median     p95     max  (ms)
----------------------------------------------------
svg_render            1.12    1.17    1.34    1.34
svg_rasterise        28.76   29.06   30.45   30.82
eink_optimize        14.75   14.97   15.35   15.44
end_to_end           48.41   48.92   50.97   51.33

Peak RSS: 47.4 MB
```