### PR TITLE
feat(widget): add calendar widget

### DIFF
--- a/custom_components/eink_dashboard/__init__.py
+++ b/custom_components/eink_dashboard/__init__.py
@@ -406,6 +406,86 @@ async def _fetch_history(
             states[entity_id]["history"] = entries
 
 
+async def _fetch_calendar_events(
+    hass: HomeAssistant,
+    widgets: list[dict[str, Any]],
+    states: dict[str, Any],
+) -> None:
+    """Fetch upcoming events for calendar widgets and inject into states.
+
+    Calls the ``calendar.get_events`` service for each unique calendar
+    entity referenced by ``widgets`` and writes the event list into
+    ``states[entity_id]["attributes"]["events"]`` so the widget
+    context builder can access multiple events without real-time HA
+    access at render time.
+
+    The fetch window starts at the current time and extends to the
+    maximum ``days_ahead`` configured across all calendar widgets that
+    reference the same entity.  Silently skips any entity where the
+    service call fails (entity offline, integration not loaded, etc.).
+
+    Args:
+        hass: Home Assistant instance.
+        widgets: Widget dicts to scan for calendar entity IDs.
+        states: Mutable states dict; events are injected in-place
+            under ``states[entity_id]["attributes"]["events"]``.
+    """
+    calendar_entities: dict[str, int] = {}
+    for w in widgets:
+        if w.get("type") == WidgetType.CALENDAR:
+            eid = w.get("entity", "")
+            if not eid:
+                continue
+            if eid not in states:
+                _LOGGER.warning(
+                    "Calendar entity %r is not in the states snapshot; "
+                    "events will not be fetched and the widget will render "
+                    "blank. Check that the entity exists in Home Assistant.",
+                    eid,
+                )
+                continue
+            try:
+                days = max(1, int(w.get("days_ahead", 7)))
+            except (ValueError, TypeError):
+                days = 7
+            if days > calendar_entities.get(eid, 0):
+                calendar_entities[eid] = days
+
+    if not calendar_entities:
+        return
+
+    now = dt.datetime.now(dt.UTC)
+    for entity_id, days in calendar_entities.items():
+        end_dt = now + timedelta(days=days)
+        try:
+            result = await hass.services.async_call(
+                "calendar",
+                "get_events",
+                {
+                    "entity_id": entity_id,
+                    "start_date_time": now.isoformat(),
+                    "end_date_time": end_dt.isoformat(),
+                },
+                blocking=True,
+                return_response=True,
+            )
+            if result is None:
+                continue
+            entity_data = result.get(entity_id)
+            raw = (
+                entity_data.get("events")
+                if isinstance(entity_data, dict)
+                else None
+            )
+            events: list[dict[str, Any]] = cast(
+                "list[dict[str, Any]]",
+                raw if isinstance(raw, list) else [],
+            )
+            states[entity_id]["attributes"]["events"] = events
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Could not fetch calendar events for %s", entity_id)
+
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "eink_dashboard/render_widget",
@@ -458,6 +538,7 @@ async def ws_render_widget(
     config = await _build_display_config(hass, entry_id)
     await _fetch_forecasts(hass, [widget], config["states"])
     await _fetch_history(hass, [widget], config["states"])
+    await _fetch_calendar_events(hass, [widget], config["states"])
     try:
         svg = await hass.async_add_executor_job(
             render_widget_svg, widget, config
@@ -523,6 +604,7 @@ async def ws_render_widgets(
     config = await _build_display_config(hass, entry_id)
     await _fetch_forecasts(hass, widgets, config["states"])
     await _fetch_history(hass, widgets, config["states"])
+    await _fetch_calendar_events(hass, widgets, config["states"])
 
     # Render all widgets in a single executor job: render_widget_svg
     # is CPU-bound (Jinja2 + resvg), and one thread per widget would

--- a/custom_components/eink_dashboard/const.py
+++ b/custom_components/eink_dashboard/const.py
@@ -249,3 +249,4 @@ class WidgetType(StrEnum):
     WEATHER = "weather"
     DEVICE_BATTERY = "device_battery"
     WASTE_SCHEDULE = "waste_schedule"
+    CALENDAR = "calendar"

--- a/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
+++ b/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
@@ -149,6 +149,22 @@ export const WIDGET_TYPES: Record<string, WidgetTypeMeta> = {
       card_style: DEFAULT_CARD_STYLE,
     },
   },
+  calendar: {
+    label: "Calendar",
+    description: "Upcoming events from a calendar entity",
+    icon: "mdi:calendar",
+    defaults: {
+      type: "calendar",
+      x: 24,
+      y: 0,
+      w: 400,
+      h: 56,
+      entity: "",
+      max_events: 5,
+      days_ahead: 7,
+      card_style: DEFAULT_CARD_STYLE,
+    },
+  },
   sensor: {
     label: "Sensor",
     description: "Single sensor with optional history sparkline graph",
@@ -835,6 +851,55 @@ export const SCHEMAS: Record<
       schema: [cardStyleSelector()],
     },
   ],
+  calendar: (d) => [
+    identitySection(),
+    {
+      name: "content",
+      type: "expandable",
+      flatten: true,
+      expanded: true,
+      title: "Content",
+      icon: "mdi:calendar",
+      schema: [
+        {
+          name: "entity",
+          required: true,
+          selector: { entity: { domain: "calendar" } },
+        },
+        { name: "title", selector: { text: {} } },
+        {
+          name: "max_events",
+          default: 5,
+          selector: {
+            number: { min: 1, max: 20, mode: "box" },
+          },
+        },
+        {
+          name: "days_ahead",
+          default: 7,
+          selector: {
+            number: { min: 1, max: 30, mode: "box" },
+          },
+        },
+      ],
+    },
+    {
+      name: "layout_pos",
+      type: "expandable",
+      flatten: true,
+      title: "Layout",
+      icon: "mdi:move-resize",
+      schema: [{ type: "grid", name: "", schema: posXYWH(d) }],
+    },
+    {
+      name: "appearance",
+      type: "expandable",
+      flatten: true,
+      title: "Appearance",
+      icon: "mdi:palette",
+      schema: [cardStyleSelector()],
+    },
+  ],
 };
 
 export const HELPERS: Record<string, string> = {
@@ -873,6 +938,8 @@ export const LABELS: Record<string, string> = {
   detail: "Detail",
   limits_min: "Y-axis minimum",
   limits_max: "Y-axis maximum",
+  max_events: "Max events",
+  days_ahead: "Days ahead",
 };
 
 // ── HA component loader ──────────────────────────────────────────
@@ -911,7 +978,10 @@ export function getSummary(widget: Widget): string {
     const s = String(widget.heading || "");
     return s.length > 30 ? s.slice(0, 30) + "…" : (s || "(empty)");
   }
-  if (t === "weather" || t === "tile" || t === "entity" || t === "sensor") {
+  if (
+    t === "weather" || t === "tile" || t === "entity"
+    || t === "sensor" || t === "calendar"
+  ) {
     return widget.entity || "(no entity)";
   }
   if (t === "device_battery") {

--- a/custom_components/eink_dashboard/frontend/src/eink-widget-picker.ts
+++ b/custom_components/eink_dashboard/frontend/src/eink-widget-picker.ts
@@ -20,6 +20,7 @@ const ICON_FALLBACK: Record<string, string> = {
   "mdi:card-text-outline": "▢",
   "mdi:format-list-bulleted": "☰",
   "mdi:chart-line": "📈",
+  "mdi:calendar": "📅",
 };
 
 /**

--- a/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
+++ b/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
@@ -406,6 +406,27 @@ export interface WasteScheduleEntry {
   label: string;
 }
 
+/** Upcoming calendar events from a single HA calendar entity. */
+export interface CalendarWidget extends WidgetBase {
+  type: "calendar";
+  /** HA calendar entity ID (e.g. "calendar.family"). */
+  entity?: string;
+  /** Optional card header text shown above the event list. */
+  title?: string;
+  /**
+   * Maximum number of upcoming events to display.
+   * Defaults to 5.
+   */
+  max_events?: number;
+  /**
+   * Look-ahead window in days used when fetching events from HA.
+   * Defaults to 7.
+   */
+  days_ahead?: number;
+  /** Decorative frame style. */
+  card_style?: CardStyle;
+}
+
 /** Waste-collection schedule widget with relative dates. */
 export interface WasteScheduleWidget extends WidgetBase {
   type: "waste_schedule";
@@ -663,6 +684,7 @@ export type Widget =
   | WeatherWidget
   | DeviceBatteryWidget
   | WasteScheduleWidget
+  | CalendarWidget
   | TileWidget
   | HeadingWidget
   | EntitiesWidget

--- a/custom_components/eink_dashboard/frontend/test/eink-dashboard-editor.test.ts
+++ b/custom_components/eink_dashboard/frontend/test/eink-dashboard-editor.test.ts
@@ -53,9 +53,10 @@ describe("WIDGET_TYPES", () => {
     "device_battery",
     "waste_schedule",
     "sensor",
+    "calendar",
   ];
 
-  it("has all 9 widget types", () => {
+  it("has all 10 widget types", () => {
     expect(Object.keys(WIDGET_TYPES).sort()).toEqual(
       ALL_TYPES.sort()
     );
@@ -100,9 +101,10 @@ describe("SCHEMAS", () => {
     "device_battery",
     "waste_schedule",
     "sensor",
+    "calendar",
   ];
 
-  it("has a schema builder for all 9 widget types", () => {
+  it("has a schema builder for all 10 widget types", () => {
     expect(Object.keys(SCHEMAS).sort()).toEqual(ALL_TYPES.sort());
   });
 

--- a/custom_components/eink_dashboard/image.py
+++ b/custom_components/eink_dashboard/image.py
@@ -28,7 +28,12 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
-from . import _async_get_locale, _fetch_forecasts, _fetch_history
+from . import (
+    _async_get_locale,
+    _fetch_calendar_events,
+    _fetch_forecasts,
+    _fetch_history,
+)
 from .battery import resolve_battery_level
 from .const import (
     DEFAULT_CONTRAST,
@@ -215,6 +220,7 @@ class EinkDashboardImage(ImageEntity):
                 states = self._build_states()
                 await self._async_fetch_forecasts(states)
                 await self._async_fetch_history(states)
+                await self._async_fetch_calendar_events(states)
                 config = {
                     "width": self._entry.options.get("width", DEFAULT_WIDTH),
                     "height": self._entry.options.get(
@@ -354,6 +360,21 @@ class EinkDashboardImage(ImageEntity):
                 in-place for sensor entities.
         """
         await _fetch_history(self.hass, self._widgets, states)
+
+    async def _async_fetch_calendar_events(
+        self, states: dict[str, Any]
+    ) -> None:
+        """Fetch calendar events for calendar widgets and inject into
+        states.
+
+        Delegates to the module-level ``_fetch_calendar_events`` so
+        the logic is shared with the WebSocket preview handlers.
+
+        Args:
+            states: Mutable states dict; event lists are injected
+                in-place for calendar entities.
+        """
+        await _fetch_calendar_events(self.hass, self._widgets, states)
 
     def _build_states(self) -> dict[str, Any]:
         """Snapshot all HA states as a plain dict for the renderer."""

--- a/custom_components/eink_dashboard/render.py
+++ b/custom_components/eink_dashboard/render.py
@@ -15,7 +15,7 @@ import functools
 import io
 import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -475,6 +475,21 @@ def _left_bar_width(m: WidgetMetrics, grayscale_levels: int) -> int:
 
 _DAY_ABBREV = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
+_MONTH_ABBREV = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
+
 
 _PROBLEM_DEVICE_CLASSES = {
     "door",
@@ -563,6 +578,138 @@ def _format_relative_date(days: int | None, raw: str) -> str:
     if days == 1:
         return "tomorrow"
     return f"in {days} days"
+
+
+def _parse_calendar_dt(
+    raw: str,
+) -> tuple[date, tuple[int, int] | None]:
+    """Parse a calendar event datetime string into date and time parts.
+
+    Handles the two formats returned by HA's ``calendar.get_events``
+    service: a date-only string (``YYYY-MM-DD``) for all-day events
+    and an ISO 8601 datetime string for timed events.  Any timezone
+    offset is stripped so the returned time reflects the local
+    wall-clock value as HA presents it to the owner's browser.
+
+    Args:
+        raw: Date string (``"YYYY-MM-DD"``) or ISO 8601 datetime
+            (``"YYYY-MM-DDTHH:MM:SS"`` or with a timezone offset).
+
+    Returns:
+        ``(event_date, (hour, minute))`` for timed events, or
+        ``(event_date, None)`` for all-day events.  Falls back to
+        today's date on any parse error.
+    """
+    sep = "T" if "T" in raw else (" " if " " in raw else "")
+    if sep:
+        date_part, time_part = raw.split(sep, 1)
+        # Take only "HH:MM" — drops seconds and any TZ offset.
+        time_clean = time_part[:5]
+        try:
+            event_date = date.fromisoformat(date_part[:10])
+            hour = int(time_clean[:2])
+            minute = int(time_clean[3:5])
+            return event_date, (hour, minute)
+        except (ValueError, IndexError):
+            pass
+    try:
+        return date.fromisoformat(raw[:10]), None
+    except ValueError:
+        return date.today(), None
+
+
+def _format_calendar_label(
+    start: str,
+    all_day: bool,
+    today: date,
+    time_format: str = "24",
+) -> str:
+    """Format a calendar event start time as a right-aligned label.
+
+    Produces a short human-readable string for the value column in a
+    calendar widget row.  The day part uses relative labels (Today,
+    Tomorrow) for events close to today and an abbreviated month+day
+    for events further away.  The time part is appended for timed
+    events (i.e. not all-day) according to ``time_format``.
+
+    Args:
+        start: Event start string as returned by
+            ``calendar.get_events`` (``"YYYY-MM-DD"`` for all-day
+            or ISO 8601 datetime for timed events).
+        all_day: When ``True``, the time part is always omitted.
+        today: Reference date used to compute relative labels.
+        time_format: ``"24"`` for 24-hour clock (e.g. ``"14:00"``),
+            ``"12"`` for 12-hour with AM/PM (e.g. ``"2:00 PM"``).
+
+    Returns:
+        A label such as ``"Today"``, ``"Today 14:00"``,
+        ``"Tomorrow"``, ``"Mon 09:30"``, or ``"Jun 16"``.
+    """
+    event_date, hm = _parse_calendar_dt(start)
+    delta = (event_date - today).days
+    if delta == 0:
+        day_label = "Today"
+    elif delta == 1:
+        day_label = "Tomorrow"
+    elif 2 <= delta < 7:
+        day_label = _DAY_ABBREV[event_date.weekday()]
+    else:
+        month = _MONTH_ABBREV[event_date.month - 1]
+        day_label = f"{month} {event_date.day}"
+
+    if all_day or hm is None:
+        return day_label
+
+    hour, minute = hm
+    if time_format == "12":
+        ampm = "AM" if hour < 12 else "PM"
+        h12 = hour % 12 or 12
+        return f"{day_label} {h12}:{minute:02d} {ampm}"
+    return f"{day_label} {hour}:{minute:02d}"
+
+
+def _is_event_now(start: str, end: str, now: datetime) -> bool:
+    """Return True when a calendar event is currently in progress.
+
+    For all-day events the comparison is date-only (the event is
+    current when today falls within ``[start_date, end_date)``).
+    For timed events both boundaries are reconstructed as naive
+    ``datetime`` objects after stripping any timezone offset, so
+    that local wall-clock time is used throughout.
+
+    Args:
+        start: Event start string (``"YYYY-MM-DD"`` or ISO 8601
+            datetime).
+        end: Event end string in the same format as ``start``.
+        now: Current local date and time (timezone-naive).
+
+    Returns:
+        ``True`` when ``now`` falls within ``[start, end)``.
+    """
+    start_date, start_hm = _parse_calendar_dt(start)
+    end_date, end_hm = _parse_calendar_dt(end)
+
+    if start_hm is None or end_hm is None:
+        # All-day: current when today is in [start_date, end_date).
+        return start_date <= now.date() < end_date
+
+    start_naive = datetime(
+        start_date.year,
+        start_date.month,
+        start_date.day,
+        start_hm[0],
+        start_hm[1],
+    )
+    end_naive = datetime(
+        end_date.year,
+        end_date.month,
+        end_date.day,
+        end_hm[0],
+        end_hm[1],
+    )
+    # Strip tz info if caller accidentally passed an aware datetime.
+    now_naive = now.replace(tzinfo=None)
+    return start_naive <= now_naive < end_naive
 
 
 def render_dashboard(

--- a/custom_components/eink_dashboard/svg_render.py
+++ b/custom_components/eink_dashboard/svg_render.py
@@ -418,6 +418,7 @@ type SvgContextFn = Callable[[Widget, DisplayConfig], dict[str, object]]
 # from this module; by this point all icon/filter helpers exist in
 # the partially-loaded svg_render module namespace.
 from .widgets import (  # noqa: E402
+    _build_calendar_context,
     _build_device_battery_context,
     _build_entities_context,
     _build_entity_context,
@@ -430,6 +431,7 @@ from .widgets import (  # noqa: E402
 )
 
 _SVG_RENDERERS: dict[str, SvgContextFn] = {
+    WidgetType.CALENDAR: _build_calendar_context,
     WidgetType.DEVICE_BATTERY: _build_device_battery_context,
     WidgetType.ENTITIES: _build_entities_context,
     WidgetType.ENTITY: _build_entity_context,

--- a/custom_components/eink_dashboard/templates/calendar.svg.j2
+++ b/custom_components/eink_dashboard/templates/calendar.svg.j2
@@ -1,0 +1,47 @@
+{%- from "_macros.svg.j2" import widget_title, card_container,
+    card_row -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{ w }}" height="{{ h }}">
+{%- if has_rows -%}
+{{ widget_title(title, title_font_sz, fill=hex_gray) }}
+{%- call card_container(
+    x=0, y=content_y, w=w, h=content_h,
+    card_style=card_style,
+    radius=m_radius, border=m_border,
+    bar_width=bar_width,
+    border_color=hex_black, bar_color=hex_gray) -%}
+{%- for row in rows -%}
+{{ card_row(
+    x=x_off, y=row.y,
+    w=w - x_off - r_inset, row_h=row_h,
+    padding=m_padding, icon_dia=m_icon_dia,
+    inner_gap=m_inner_gap, border=icon_stroke_w,
+    font_primary=m_font_primary,
+    font_secondary=m_font_secondary,
+    icon_inner=m_icon_inner,
+    letter_font_sz=m_font_letter,
+    primary=row.primary,
+    secondary=row.secondary,
+    value=row.value,
+    icon_svg=row.icon_svg,
+    icon_fill=row.icon_fill,
+    icon_outline=row.icon_outline,
+    primary_fill=hex_black,
+    value_fill=row.value_fill,
+    secondary_fill=row.secondary_fill,
+    letter=row.letter,
+    lpad=lpad, rpad=rpad,
+    hex_black=hex_black, hex_white=hex_white) }}
+{%- if not loop.last -%}
+<line
+  x1="{{ x_off + lpad }}"
+  y1="{{ row.y + row_h }}"
+  x2="{{ w - r_inset - rpad }}"
+  y2="{{ row.y + row_h }}"
+  stroke="{{ hex_light_gray }}"
+  stroke-width="{{ divider_stroke_w }}"/>
+{%- endif -%}
+{%- endfor -%}
+{%- endcall -%}
+{%- endif -%}
+</svg>

--- a/custom_components/eink_dashboard/widgets/__init__.py
+++ b/custom_components/eink_dashboard/widgets/__init__.py
@@ -7,6 +7,7 @@ template context dict.  This package re-exports all builders so
 import.
 """
 
+from .calendar import _build_calendar_context
 from .device_battery import (
     _build_device_battery_context,
 )
@@ -24,6 +25,7 @@ from .waste_schedule import (
 from .weather import _build_weather_context
 
 __all__ = [
+    "_build_calendar_context",
     "_build_device_battery_context",
     "_build_entities_context",
     "_build_entity_context",

--- a/custom_components/eink_dashboard/widgets/calendar.py
+++ b/custom_components/eink_dashboard/widgets/calendar.py
@@ -1,0 +1,184 @@
+"""Calendar widget context builder."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ..const import (
+    COLOR_BLACK,
+    COLOR_GRAY,
+    DEFAULT_CARD_STYLE,
+    DEFAULT_ROW_H,
+    PADDING,
+    DisplayConfig,
+    Widget,
+    color_to_hex,
+)
+from ..svg_render import _mdi_svg_filter
+from ._helpers import (
+    _auto_row_height,
+    _card_insets,
+    _color_context,
+    _metrics_context,
+    _title_layout,
+    _widget_dim,
+)
+
+
+def _build_calendar_context(
+    widget: Widget,
+    config: DisplayConfig,
+) -> dict[str, object]:
+    """Build Jinja2 template context for the calendar widget.
+
+    Renders upcoming calendar events as a list of card rows.
+    Events are sourced from
+    ``states[entity_id]["attributes"]["events"]``, which is
+    injected by ``_fetch_calendar_events()`` before rendering.
+
+    Icon urgency rules:
+
+    - Happening now: black-filled circle, black label.
+    - Today (not now): gray-filled circle, gray label.
+    - Future: outlined circle (white fill, black stroke),
+      gray label.
+
+    Args:
+        widget: Widget config dict.  Recognised keys:
+            ``entity`` (calendar entity ID),
+            ``max_events`` (int, default 5),
+            ``title`` (optional header string),
+            ``card_style`` (``"border"``, ``"left_bar"``,
+            or ``"none"``), ``x``, ``w``, ``h``.
+        config: Display config with ``states``,
+            ``grayscale_levels``, and ``time_format``.
+
+    Returns:
+        Template context dict consumed by
+        ``calendar.svg.j2``.  Returns
+        ``{"w": …, "h": …, "has_rows": False}`` when the
+        entity is absent, events list is empty, or no events
+        remain after capping at ``max_events``.
+    """
+    from ..render import (
+        _compute_metrics,
+        _format_calendar_label,
+        _get_today,
+        _is_event_now,
+        _parse_calendar_dt,
+    )
+
+    x = widget.get("x", PADDING)
+    svg_w = _widget_dim(widget, "w", config["width"] - x)
+
+    entity_id: str = widget.get("entity", "")
+    max_events: int = int(widget.get("max_events", 5))
+    card_style = widget.get("card_style", DEFAULT_CARD_STYLE)
+    title: str = widget.get("title", "")
+    time_format: str = config.get("time_format", "24")
+    states = config.get("states", {})
+    grayscale_levels = config.get("grayscale_levels", 16)
+
+    empty_ctx: dict[str, object] = {
+        "w": svg_w,
+        "h": _widget_dim(widget, "h", DEFAULT_ROW_H),
+        "has_rows": False,
+        **_color_context(),
+    }
+
+    if not entity_id:
+        return empty_ctx
+
+    entity_state = states.get(entity_id)
+    if entity_state is None:
+        return empty_ctx
+
+    attrs = entity_state.get("attributes", {})
+    raw_events: list[dict[str, object]] = attrs.get("events", [])
+
+    if not raw_events:
+        return empty_ctx
+
+    visible = list(raw_events[:max_events])
+    if not visible:
+        return empty_ctx
+
+    today = _get_today()
+    now = datetime.now()
+
+    num_rows = len(visible)
+    svg_h = _widget_dim(
+        widget,
+        "h",
+        _auto_row_height(title, num_rows),
+    )
+    title_font_sz, content_y, content_h = _title_layout(title, svg_h)
+    row_h = content_h // num_rows
+
+    m = _compute_metrics(row_h)
+    icon_stroke_w = m.border * 3 if grayscale_levels <= 2 else m.border
+    divider_stroke_w = m.divider * 3 if grayscale_levels <= 2 else m.divider
+    x_off, r_inset, bar_width = _card_insets(m, card_style, grayscale_levels)
+    lpad = m.padding if x_off == 0 else 0
+    rpad = m.padding if r_inset == 0 else 0
+
+    # Build the calendar icon once; all rows share the same glyph.
+    icon_svg = _mdi_svg_filter("calendar", m.icon_inner)
+
+    rows: list[dict[str, object]] = []
+    for i, event in enumerate(visible):
+        start = str(event.get("start", ""))
+        end = str(event.get("end", ""))
+        summary = str(event.get("summary", ""))
+        all_day = bool(event.get("all_day", False))
+
+        label = _format_calendar_label(start, all_day, today, time_format)
+        is_now = _is_event_now(start, end, now)
+        start_date, _ = _parse_calendar_dt(start)
+        is_today = start_date == today
+
+        if is_now:
+            icon_fill = color_to_hex(COLOR_BLACK)
+            value_fill = color_to_hex(COLOR_BLACK)
+            use_outline = False
+        else:
+            icon_fill = color_to_hex(COLOR_GRAY)
+            value_fill = color_to_hex(COLOR_GRAY)
+            use_outline = not is_today
+
+        rows.append(
+            {
+                "y": content_y + i * row_h,
+                "primary": summary,
+                "secondary": "",
+                "value": label,
+                "icon_svg": icon_svg,
+                "icon_outline": use_outline,
+                "icon_fill": icon_fill,
+                "secondary_fill": color_to_hex(COLOR_GRAY),
+                "value_fill": value_fill,
+                "letter": "",
+            }
+        )
+
+    return {
+        "w": svg_w,
+        "h": svg_h,
+        "has_rows": True,
+        "title": title,
+        "title_font_sz": title_font_sz,
+        "content_y": content_y,
+        "content_h": content_h,
+        "card_style": card_style,
+        "bar_width": bar_width,
+        **_metrics_context(m),
+        **_color_context(),
+        "row_h": row_h,
+        "rows": rows,
+        "x_off": x_off,
+        "r_inset": r_inset,
+        "lpad": lpad,
+        "rpad": rpad,
+        "icon_stroke_w": icon_stroke_w,
+        "divider_stroke_w": divider_stroke_w,
+    }

--- a/tests/test_render_calendar.py
+++ b/tests/test_render_calendar.py
@@ -1,0 +1,649 @@
+"""Tests for the calendar widget renderer."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from typing import Any, ClassVar
+from unittest.mock import patch
+
+from custom_components.eink_dashboard.const import (
+    COLOR_GRAY,
+    COLOR_LIGHT_GRAY,
+    DEFAULT_ROW_H,
+    color_to_hex,
+)
+from custom_components.eink_dashboard.render import (
+    _compute_metrics,
+    _format_calendar_label,
+    _is_event_now,
+    _parse_calendar_dt,
+    render_dashboard,
+)
+from custom_components.eink_dashboard.svg_render import render_widget_svg
+from tests.helpers import (
+    assert_all_white,
+    assert_card_border,
+    assert_has_dark_pixels,
+    assert_has_gray_pixels,
+    assert_scales_proportionally,
+    assert_vertically_centered,
+    make_config,
+    pixel,
+    render_to_image,
+)
+
+_TODAY = dt.date(2026, 6, 11)
+_TOMORROW = dt.date(2026, 6, 12)
+_FUTURE = dt.date(2026, 6, 15)  # Monday, 4 days from _TODAY
+_PATCH_NOW = "custom_components.eink_dashboard.render.date"
+
+# End times are chosen so _is_event_now() always returns False
+# during any real test run (events ended before the day began),
+# giving deterministic "today but not now" = gray-filled icon.
+MOCK_CALENDAR_STATES: dict[str, Any] = {
+    "calendar.family": {
+        "state": "off",
+        "attributes": {
+            "friendly_name": "Family Calendar",
+            "events": [
+                {
+                    "start": "2026-06-12T10:00:00",
+                    "end": "2026-06-12T11:00:00",
+                    "summary": "Doctor Appointment",
+                    "all_day": False,
+                },
+                {
+                    "start": "2026-06-15T14:00:00",
+                    "end": "2026-06-15T15:00:00",
+                    "summary": "Team Meeting",
+                    "all_day": False,
+                },
+            ],
+        },
+    },
+    # today_cal: event today from 00:00–00:01 so is_now is always
+    # False but start_date == today → gray-filled icon.
+    "calendar.today_cal": {
+        "state": "off",
+        "attributes": {
+            "friendly_name": "Today Calendar",
+            "events": [
+                {
+                    "start": "2026-06-11T00:00:00",
+                    "end": "2026-06-11T00:01:00",
+                    "summary": "Morning Standup",
+                    "all_day": False,
+                },
+            ],
+        },
+    },
+    "calendar.allday_cal": {
+        "state": "off",
+        "attributes": {
+            "friendly_name": "All-Day Calendar",
+            "events": [
+                {
+                    "start": "2026-06-11",
+                    "end": "2026-06-12",
+                    "summary": "All Day Event",
+                    "all_day": True,
+                },
+            ],
+        },
+    },
+    "calendar.future_only": {
+        "state": "off",
+        "attributes": {
+            "friendly_name": "Future Calendar",
+            "events": [
+                {
+                    "start": "2026-06-15T14:00:00",
+                    "end": "2026-06-15T15:00:00",
+                    "summary": "Future Event",
+                    "all_day": False,
+                },
+            ],
+        },
+    },
+}
+
+
+class TestCalendarHelpers:
+    """Unit tests for calendar helper functions in render.py."""
+
+    def test_parse_date_only(self) -> None:
+        # All-day events use date-only strings; time part is None.
+        d, hm = _parse_calendar_dt("2026-06-11")
+        assert d == dt.date(2026, 6, 11)
+        assert hm is None
+
+    def test_parse_datetime_local(self) -> None:
+        # Local datetime (no timezone) returns (date, (hour, minute)).
+        d, hm = _parse_calendar_dt("2026-06-11T10:30:00")
+        assert d == dt.date(2026, 6, 11)
+        assert hm == (10, 30)
+
+    def test_parse_datetime_with_tz_offset(self) -> None:
+        # Timezone offset is stripped; local wall-clock values kept.
+        d, hm = _parse_calendar_dt("2026-06-11T14:00:00+02:00")
+        assert d == dt.date(2026, 6, 11)
+        assert hm == (14, 0)
+
+    def test_parse_datetime_space_separator(self) -> None:
+        # HA sometimes uses a space instead of "T" as separator.
+        d, hm = _parse_calendar_dt("2026-06-11 09:15:00")
+        assert d == dt.date(2026, 6, 11)
+        assert hm == (9, 15)
+
+    def test_parse_invalid_falls_back_to_today(self) -> None:
+        # An unparseable string falls back to date.today().
+        d, hm = _parse_calendar_dt("unavailable")
+        assert d == dt.date.today()
+        assert hm is None
+
+    def test_format_label_today_allday(self) -> None:
+        # All-day event today formats as bare "Today".
+        label = _format_calendar_label(
+            "2026-06-11",
+            all_day=True,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Today"
+
+    def test_format_label_today_timed(self) -> None:
+        # Timed event today appends "HH:MM" in 24-hour format.
+        label = _format_calendar_label(
+            "2026-06-11T14:30:00",
+            all_day=False,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Today 14:30"
+
+    def test_format_label_tomorrow_timed(self) -> None:
+        # Tomorrow's timed event uses "Tomorrow HH:MM".
+        label = _format_calendar_label(
+            "2026-06-12T10:00:00",
+            all_day=False,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Tomorrow 10:00"
+
+    def test_format_label_within_week(self) -> None:
+        # 3 days from now uses a weekday abbreviation.
+        # 2026-06-14 is a Sunday.
+        label = _format_calendar_label(
+            "2026-06-14T09:00:00",
+            all_day=False,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Sun 9:00"
+
+    def test_format_label_beyond_week_timed(self) -> None:
+        # Timed events 8+ days out use "Mon DD HH:MM".
+        label = _format_calendar_label(
+            "2026-06-22T09:00:00",
+            all_day=False,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Jun 22 9:00"
+
+    def test_format_label_beyond_week_allday(self) -> None:
+        # All-day events 8+ days out use bare "Mon DD" (no time).
+        label = _format_calendar_label(
+            "2026-06-22",
+            all_day=True,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Jun 22"
+
+    def test_format_label_12hour(self) -> None:
+        # 12-hour mode appends AM/PM.
+        label = _format_calendar_label(
+            "2026-06-12T14:30:00",
+            all_day=False,
+            today=dt.date(2026, 6, 11),
+            time_format="12",
+        )
+        assert label == "Tomorrow 2:30 PM"
+
+    def test_format_label_midnight(self) -> None:
+        # Midnight formats as 0:00 in 24-hour mode.
+        label = _format_calendar_label(
+            "2026-06-12T00:00:00",
+            all_day=False,
+            today=dt.date(2026, 6, 11),
+        )
+        assert label == "Tomorrow 0:00"
+
+    def test_is_event_now_timed_during(self) -> None:
+        # A timed event is "now" when current time is within its window.
+        now = dt.datetime(2026, 6, 11, 10, 30)
+        assert _is_event_now("2026-06-11T10:00:00", "2026-06-11T11:00:00", now)
+
+    def test_is_event_not_now_after(self) -> None:
+        # An event that already ended is not "now".
+        now = dt.datetime(2026, 6, 11, 12, 0)
+        assert not _is_event_now(
+            "2026-06-11T10:00:00", "2026-06-11T11:00:00", now
+        )
+
+    def test_is_event_not_now_before(self) -> None:
+        # An event that hasn't started is not "now".
+        now = dt.datetime(2026, 6, 11, 9, 0)
+        assert not _is_event_now(
+            "2026-06-11T10:00:00", "2026-06-11T11:00:00", now
+        )
+
+    def test_is_allday_event_now(self) -> None:
+        # All-day event is "now" when today falls within [start, end).
+        now = dt.datetime(2026, 6, 11, 15, 0)
+        assert _is_event_now("2026-06-11", "2026-06-12", now)
+
+    def test_is_allday_event_not_now_next_day(self) -> None:
+        # All-day event is not "now" the day after it ends.
+        now = dt.datetime(2026, 6, 12, 8, 0)
+        assert not _is_event_now("2026-06-11", "2026-06-12", now)
+
+
+class TestRenderCalendar:
+    """Verify rendering of calendar widgets."""
+
+    _DEFAULTS: ClassVar[dict[str, object]] = {
+        "width": 400,
+        "height": 300,
+        "grayscale_levels": 16,
+        "time_format": "24",
+        "states": MOCK_CALENDAR_STATES,
+    }
+
+    def _config(self, **overrides: object) -> dict[str, object]:
+        """Build a display config with optional overrides."""
+        return make_config(self._DEFAULTS, **overrides)
+
+    def _widget(self, **overrides: object) -> dict[str, object]:
+        """Build a calendar widget config with sensible defaults."""
+        base: dict[str, object] = {
+            "type": "calendar",
+            "entity": "calendar.family",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 112,
+        }
+        base.update(overrides)
+        return base
+
+    # ── Structural tests ──────────────────────────────
+
+    def test_calendar_draws_event_content(self) -> None:
+        # Dark pixels appear in the widget area when events are present.
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([self._widget()], self._config())
+        assert_has_dark_pixels(img, 0, 0, 400, 112)
+
+    def test_calendar_12h_time_format(self) -> None:
+        # time_format="12" in the display config is forwarded to event
+        # labels; the widget renders successfully and produces content.
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image(
+                [self._widget()], self._config(time_format="12")
+            )
+        assert_has_dark_pixels(img, 0, 0, 400, 112)
+
+    def test_calendar_no_entity_white(self) -> None:
+        # Missing entity produces blank output without crashing.
+        w = self._widget(entity="calendar.nonexistent")
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_all_white(img, 0, 0, 400, 300)
+
+    def test_calendar_no_events_white(self) -> None:
+        # Empty events list produces blank output.
+        states: dict[str, Any] = {
+            "calendar.empty": {
+                "state": "off",
+                "attributes": {
+                    "friendly_name": "Empty",
+                    "events": [],
+                },
+            }
+        }
+        w = self._widget(entity="calendar.empty", h=56)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config(states=states))
+        assert_all_white(img, 0, 0, 400, 300)
+
+    def test_calendar_card_border(self) -> None:
+        # card_style="border" draws dark pixels on all four edges.
+        h = 112
+        row_h = h // 2
+        m = _compute_metrics(row_h)
+        w = self._widget(h=h, card_style="border")
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_card_border(img, 400, h, m)
+
+    def test_calendar_card_style_none_is_default(self) -> None:
+        # Omitting card_style must produce byte-identical output to "none".
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            with_none = render_dashboard(
+                [self._widget(card_style="none")], self._config()
+            )
+            without = render_dashboard([self._widget()], self._config())
+        assert with_none == without
+
+    def test_calendar_card_left_bar(self) -> None:
+        # card_style="left_bar" draws a gray bar along the left edge.
+        h = 56
+        m = _compute_metrics(h)
+        w = self._widget(
+            entity="calendar.future_only",
+            h=h,
+            card_style="left_bar",
+        )
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_has_gray_pixels(
+            img,
+            0,
+            2,
+            m.left_bar + 2,
+            h - 2,
+            low=COLOR_GRAY - 20,
+            high=COLOR_GRAY + 20,
+        )
+
+    def test_calendar_divider_between_rows(self) -> None:
+        # Multiple events produce a light-gray divider at the row boundary.
+        h = 112
+        row_h = h // 2
+        m = _compute_metrics(row_h)
+        w = self._widget(h=h, max_events=2)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_has_gray_pixels(
+            img,
+            m.padding + 10,
+            row_h - m.divider,
+            380,
+            row_h + m.divider + 1,
+            low=COLOR_LIGHT_GRAY - 20,
+            high=COLOR_LIGHT_GRAY + 20,
+        )
+
+    def test_calendar_no_divider_single_event(self) -> None:
+        # Single event widget has no divider below the row.
+        h = 56
+        w = self._widget(entity="calendar.future_only", h=h)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_all_white(img, 0, h + 1, 400, h + 4)
+
+    def test_calendar_icon_present(self) -> None:
+        # Calendar icon (dark pixels) appears in the icon area.
+        h = 56
+        m = _compute_metrics(h)
+        w = self._widget(entity="calendar.future_only", h=h)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_has_dark_pixels(img, m.padding, 0, m.padding + m.icon_dia, h)
+
+    # ── Alignment tests ───────────────────────────────
+
+    def test_calendar_icon_vertically_centered(self) -> None:
+        # Icon circle is vertically centered with the primary text.
+        h = 56
+        m = _compute_metrics(h)
+        w = self._widget(entity="calendar.future_only", h=h)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        icon_region = (m.padding, 0, m.padding + m.icon_dia, h)
+        text_x = m.padding + m.icon_dia + m.inner_gap
+        text_region = (text_x, 0, 380, h)
+        assert_vertically_centered(
+            img, icon_region, text_region, tolerance=3.0
+        )
+
+    # ── Scaling tests ─────────────────────────────────
+
+    def test_calendar_scales_proportionally(self) -> None:
+        # Doubling h doubles the icon bounding box height.
+        m_small = _compute_metrics(56)
+        m_large = _compute_metrics(112)
+        w_small = self._widget(entity="calendar.future_only", h=56)
+        w_large = self._widget(entity="calendar.future_only", h=112)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img_s = render_to_image([w_small], self._config())
+            img_l = render_to_image([w_large], self._config())
+        assert_scales_proportionally(
+            img_s,
+            img_l,
+            region_small=(
+                m_small.padding,
+                0,
+                m_small.padding + m_small.icon_dia,
+                56,
+            ),
+            region_large=(
+                m_large.padding,
+                0,
+                m_large.padding + m_large.icon_dia,
+                112,
+            ),
+            expected_ratio=2.0,
+        )
+
+    # ── Auto-sizing tests ─────────────────────────────
+
+    def test_calendar_auto_height_single_event(self) -> None:
+        # Without explicit h and one event, height == DEFAULT_ROW_H.
+        w = {
+            "type": "calendar",
+            "entity": "calendar.future_only",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+        }
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == DEFAULT_ROW_H
+
+    def test_calendar_auto_height_two_events(self) -> None:
+        # Without explicit h and two events, height == 2 * DEFAULT_ROW_H.
+        w = {
+            "type": "calendar",
+            "entity": "calendar.family",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "max_events": 2,
+        }
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == 2 * DEFAULT_ROW_H
+
+    def test_calendar_explicit_h_preserved(self) -> None:
+        # An explicit h overrides auto-sizing regardless of event count.
+        w = self._widget(h=200)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == 200
+
+    # ── Content / data tests ──────────────────────────
+
+    def test_calendar_max_events_limits_rows(self) -> None:
+        # max_events=1 forces only one row despite two events available.
+        w = {
+            "type": "calendar",
+            "entity": "calendar.family",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "max_events": 1,
+        }
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        m = re.search(r'height="(\d+)"', svg)
+        assert m is not None
+        assert int(m.group(1)) == DEFAULT_ROW_H
+
+    def test_calendar_event_summary_in_svg(self) -> None:
+        # Event summary text appears in the rendered SVG.
+        w = self._widget(max_events=1)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        assert "Doctor Appointment" in svg
+
+    def test_calendar_all_day_event_no_time(self) -> None:
+        # All-day event label is "Today" with no colon-separated time.
+        w = self._widget(entity="calendar.allday_cal", h=56)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        assert "Today" in svg
+        # Extract the 10 characters after "Today" and verify no ":"
+        today_idx = svg.index("Today")
+        after = svg[today_idx + len("Today") : today_idx + len("Today") + 10]
+        assert ":" not in after
+
+    def test_calendar_timed_event_shows_time(self) -> None:
+        # Timed event label includes the start time in HH:MM format.
+        w = self._widget(entity="calendar.future_only", h=56)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        # Future event starts at 14:00.
+        assert "14:00" in svg
+
+    def test_calendar_title_shown(self) -> None:
+        # When title is set, title text appears in the SVG output.
+        w = self._widget(h=80, title="My Events")
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        assert "My Events" in svg
+
+    def test_calendar_date_right_aligned(self) -> None:
+        # Date/time label appears near the right edge of the widget.
+        h = 56
+        w = self._widget(entity="calendar.future_only", h=h)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_has_dark_pixels(img, 300, 0, 400, h, threshold=200)
+
+    # ── Urgency / icon fill tests ─────────────────────
+
+    def test_calendar_today_event_gray_filled_icon(self) -> None:
+        # Today's event (not in progress) renders with a gray-filled
+        # icon circle.  The SVG should contain the gray hex color on a
+        # circle element.
+        w = self._widget(entity="calendar.today_cal", h=56)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        # Gray fill hex (#787878) must appear — used as icon_fill
+        # on the filled-circle path in _macros.svg.j2.
+        assert color_to_hex(COLOR_GRAY) in svg
+
+    def test_calendar_future_event_outlined_icon(self) -> None:
+        # Future event renders with an outlined circle (black stroke,
+        # white fill).  The circle element has a stroke-width attribute.
+        w = self._widget(entity="calendar.future_only", h=56)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config())
+        # Outlined mode emits stroke and stroke-width on the circle.
+        assert "stroke-width=" in svg
+
+    def test_calendar_future_event_white_interior(self) -> None:
+        # Outlined icon has a white interior (not filled with gray).
+        h = 80
+        m = _compute_metrics(h)
+        w = self._widget(entity="calendar.future_only", h=h)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        ring_y = h // 2
+        # The leftmost arc pixel should be the black stroke.
+        assert pixel(img, m.padding, ring_y) < 64
+        # Just inside the stroke, before the glyph: white fill.
+        assert pixel(img, m.padding + m.border + 3, ring_y) > 200
+
+    # ── 2-level display tests ─────────────────────────
+
+    def test_calendar_2level_icon_stroke_widened(self) -> None:
+        # On 2-level displays the icon circle stroke is 3× m.border.
+        m = _compute_metrics(DEFAULT_ROW_H)
+        w = self._widget(
+            entity="calendar.future_only",
+            h=DEFAULT_ROW_H,
+        )
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config(grayscale_levels=2))
+        expected = m.border * 3
+        assert f'stroke-width="{expected}"' in svg, (
+            f"2-level stroke-width should be {expected}"
+            f" (3 × m.border={m.border})"
+        )
+
+    def test_calendar_2level_divider_stroke_widened(self) -> None:
+        # On 2-level displays the row divider stroke is 3× m.divider.
+        m = _compute_metrics(DEFAULT_ROW_H)
+        w = self._widget(h=2 * DEFAULT_ROW_H, max_events=2)
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            svg = render_widget_svg(w, self._config(grayscale_levels=2))
+        expected = m.divider * 3
+        assert f'stroke-width="{expected}"' in svg, (
+            f"2-level divider stroke-width should be {expected}"
+            f" (3 × m.divider={m.divider})"
+        )
+
+    def test_calendar_border_single_padding(self) -> None:
+        # With card_style="border", card_container provides x_off=padding;
+        # card_row must not add its own padding again.  The icon circle's
+        # left arc should appear in the strip [m.padding, 2*m.padding].
+        h = DEFAULT_ROW_H
+        m = _compute_metrics(h)
+        w = self._widget(
+            entity="calendar.future_only",
+            h=h,
+            card_style="border",
+        )
+        with patch(_PATCH_NOW, wraps=dt.date) as mock_dt:
+            mock_dt.today.return_value = _TODAY
+            img = render_to_image([w], self._config())
+        assert_has_dark_pixels(
+            img,
+            m.padding,
+            0,
+            2 * m.padding,
+            h,
+            threshold=200,
+        )


### PR DESCRIPTION
## Summary

- Adds a new `calendar` widget that displays upcoming events from a Home Assistant calendar entity
- Events are fetched via the `calendar.get_events` service with a configurable look-ahead window (`days_ahead`, default 7)
- Urgency styling: current events get a filled black circle, today's events a gray fill, future events an outlined circle
- Configurable via `entity`, `max_events` (default 5), and `days_ahead` (default 7)

## Test plan

- [ ] Add a `calendar` widget in the HA dashboard editor and select a calendar entity
- [ ] Verify upcoming events are displayed correctly
- [ ] Verify urgency styling (is_now / is_today / future) renders as expected on the e-ink display
- [ ] Run `tests/test_render_calendar.py` to confirm backend rendering passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)