### PR TITLE
feat(widgets): add attribute-based data source to graph widget

### DIFF
--- a/custom_components/eink_dashboard/__init__.py
+++ b/custom_components/eink_dashboard/__init__.py
@@ -372,18 +372,22 @@ async def _fetch_history(
         if needs_history:
             # Collect all entity IDs from the entities list,
             # single entity= key, and flat editor keys entity_2/3.
+            # Entities configured with data_source="attribute" read
+            # a forecast-style attribute instead, so they are
+            # skipped here to avoid an unnecessary recorder query.
             eids: list[str] = []
             entities_list = w.get("entities")
             if isinstance(entities_list, list):
                 for e in entities_list:
                     if isinstance(e, dict):
                         eid = str(e.get("entity", ""))
-                        if eid:
+                        if eid and e.get("data_source") != "attribute":
                             eids.append(eid)
             if not eids:
-                eid = str(w.get("entity", ""))
-                if eid:
-                    eids.append(eid)
+                if w.get("data_source") != "attribute":
+                    eid = str(w.get("entity", ""))
+                    if eid:
+                        eids.append(eid)
                 for suffix in ("_2", "_3"):
                     eid2 = str(w.get(f"entity{suffix}", ""))
                     if eid2:

--- a/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
+++ b/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
@@ -1246,6 +1246,37 @@ export const SCHEMAS: Record<
         { name: "icon", selector: { icon: {} } },
         { name: "unit", selector: { text: {} } },
         {
+          name: "data_source",
+          default: "history",
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: [
+                { value: "history", label: "History (recorder)" },
+                { value: "attribute", label: "Attribute (forecast)" },
+              ],
+            },
+          },
+        },
+        { name: "attribute", selector: { text: {} } },
+        {
+          type: "grid",
+          name: "",
+          schema: [
+            {
+              name: "attribute_timestamp_key",
+              selector: { text: {} },
+            },
+            {
+              name: "attribute_value_key",
+              selector: { text: {} },
+            },
+          ],
+        },
+        // hours_to_show, points_per_hour, and aggregate_func only
+        // apply to data_source="history"; ha-form has no field-level
+        // conditional visibility to hide them for "attribute" mode.
+        {
           type: "grid",
           name: "",
           schema: [
@@ -1487,6 +1518,9 @@ export const LABELS: Record<string, string> = {
   temperature_entity: "Temperature sensor",
   humidity_entity: "Humidity sensor",
   graph: "Graph type",
+  data_source: "Data source",
+  attribute_timestamp_key: "Timestamp key",
+  attribute_value_key: "Value key",
   hours_to_show: "Hours to show",
   detail: "Detail",
   limits_min: "Y-axis minimum",

--- a/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
+++ b/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
@@ -900,6 +900,31 @@ export interface GraphEntityConfig {
    * ``"dotted"`` (3rd).
    */
   line_style?: "solid" | "dashed" | "dotted";
+  /**
+   * Where this entity's time-series data comes from.  ``"history"``
+   * (default) reads from the HA recorder (backward-looking actual
+   * values).  ``"attribute"`` reads from a named entity attribute
+   * containing a list of timestamped data points, useful for
+   * forward-looking forecasts (solar production, energy prices).
+   */
+  data_source?: "history" | "attribute";
+  /**
+   * Entity attribute name holding the time-series list.  Required
+   * when {@link data_source} is ``"attribute"``.  Example:
+   * ``"timeseries"``, ``"forecast"``.
+   */
+  attribute?: string;
+  /**
+   * Key for the timestamp in each attribute list entry.  Accepts
+   * ISO 8601 strings or Unix timestamps.  Default: ``"timestamp"``.
+   */
+  attribute_timestamp_key?: string;
+  /**
+   * Key for the numeric value in each attribute list entry.
+   * Required when {@link data_source} is ``"attribute"``.  Example:
+   * ``"w"`` for watts, ``"price"`` for energy price.
+   */
+  attribute_value_key?: string;
 }
 
 /**
@@ -928,6 +953,28 @@ export interface GraphWidget extends WidgetBase {
   icon?: string;
   /** Unit string override shown next to the current state value. */
   unit?: string;
+  /**
+   * Data source for the primary entity.  ``"history"`` (default)
+   * reads from the recorder; ``"attribute"`` reads from a named
+   * entity attribute containing a time-series list (e.g. a solar
+   * or price forecast).
+   */
+  data_source?: "history" | "attribute";
+  /**
+   * Entity attribute name holding the time-series list.  Required
+   * when {@link data_source} is ``"attribute"``.
+   */
+  attribute?: string;
+  /**
+   * Key for the timestamp in each attribute list entry.
+   * Default: ``"timestamp"``.
+   */
+  attribute_timestamp_key?: string;
+  /**
+   * Key for the numeric value in each attribute list entry.
+   * Required when {@link data_source} is ``"attribute"``.
+   */
+  attribute_value_key?: string;
   /** History window in hours. Default: 24. */
   hours_to_show?: number;
   /**

--- a/custom_components/eink_dashboard/widgets/graph.py
+++ b/custom_components/eink_dashboard/widgets/graph.py
@@ -206,6 +206,7 @@ def _threshold_gradient_stops(
     y_range = y_max - y_min
 
     def _offset(val: float) -> str:
+        """Convert a data value to an SVG gradient offset percentage."""
         # High value → small offset (near top of SVG gradient).
         pct = (y_max - val) / y_range * 100.0
         pct = max(0.0, min(100.0, pct))

--- a/custom_components/eink_dashboard/widgets/graph.py
+++ b/custom_components/eink_dashboard/widgets/graph.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import math
 from typing import Any, cast
 
 from ..const import (
@@ -66,6 +67,11 @@ _SHADE_VALUES: dict[str, int] = {
     "medium": COLOR_MEDIUM_GRAY,
     "light": COLOR_LIGHT_GRAY,
 }
+
+# Maximum data points kept from attribute sources.  Exceeding this
+# triggers stride-based downsampling to cap render cost.  Typical
+# forecasts (48-96 entries) are never affected.
+_MAX_ATTRIBUTE_POINTS: int = 500
 
 
 def _rgb_hex_to_grayscale(
@@ -1083,20 +1089,122 @@ def _extract_entity_points(
         list(state.get("history", [])) if isinstance(state, dict) else []
     )
     if raw_hist:
-        t_latest = max(float(str(e.get("lu", 0))) for e in raw_hist)
-        cutoff = t_latest - hours_to_show * 3600
-        raw_hist = [e for e in raw_hist if float(str(e.get("lu", 0))) > cutoff]
+        t_latest = max(
+            (
+                float(str(e.get("lu", 0)))
+                for e in raw_hist
+                if math.isfinite(float(str(e.get("lu", 0))))
+            ),
+            default=None,
+        )
+        if t_latest is None:
+            raw_hist = []
+        else:
+            cutoff = t_latest - hours_to_show * 3600
+            raw_hist = [
+                e
+                for e in raw_hist
+                if math.isfinite(float(str(e.get("lu", 0))))
+                and float(str(e.get("lu", 0))) > cutoff
+            ]
     numeric: list[tuple[float, float]] = []
     for entry in raw_hist:
         s = entry.get("s", "")
         lu = entry.get("lu", 0.0)
         try:
             val = float(str(s))
-            numeric.append((float(str(lu)), val))
+            ts = float(str(lu))
         except (ValueError, TypeError):
             continue
+        if not math.isfinite(val) or not math.isfinite(ts):
+            continue
+        numeric.append((ts, val))
     if len(numeric) >= 2:
         return _aggregate_history(numeric, points_per_hour, aggregate_func)
+    return []
+
+
+def _parse_attribute_timestamp(value: object) -> float | None:
+    """Parse a timestamp field from an attribute time-series entry.
+
+    Accepts either a Unix timestamp (int/float, or a numeric string)
+    or an ISO 8601 string (e.g. ``"2026-07-01T04:00:00+00:00"``).
+
+    Args:
+        value: Raw timestamp value from the attribute entry.
+
+    Returns:
+        Unix timestamp in seconds, or ``None`` if unparseable.
+    """
+    try:
+        result = float(str(value))
+        if not math.isfinite(result):
+            return None
+        return result
+    except (ValueError, TypeError):
+        pass
+    try:
+        return datetime.datetime.fromisoformat(str(value)).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_attribute_points(
+    desc: dict[str, object],
+    states_dict: dict[str, Any],
+) -> list[tuple[float, float]]:
+    """Extract time-series data from an entity attribute.
+
+    Reads a list of dicts from ``states_dict[entity]["attributes"]
+    [attribute]``, pulling the timestamp and value out of each entry
+    via the descriptor's configured key names. Used for forward-
+    looking forecast data (solar production, energy prices, etc.)
+    that is not available through the recorder.
+
+    Args:
+        desc: Entity descriptor dict from ``_normalize_entities()``,
+            with ``attribute``, ``attribute_timestamp_key``, and
+            ``attribute_value_key`` keys.
+        states_dict: States dict from the display config.
+
+    Returns:
+        Sorted oldest-to-newest list of ``(timestamp, value)`` pairs,
+        or an empty list when the attribute is missing or fewer than
+        two numeric entries survive parsing.
+    """
+    eid = str(desc["entity"])
+    attribute = str(desc.get("attribute", ""))
+    ts_key = str(desc.get("attribute_timestamp_key", "timestamp"))
+    value_key = str(desc.get("attribute_value_key", ""))
+    state = states_dict.get(eid, {})
+    attrs = state.get("attributes", {}) if isinstance(state, dict) else {}
+    raw_list = attrs.get(attribute, []) if isinstance(attrs, dict) else []
+
+    numeric: list[tuple[float, float]] = []
+    if isinstance(raw_list, list):
+        for entry in raw_list:
+            if not isinstance(entry, dict):
+                continue
+            ts = _parse_attribute_timestamp(entry.get(ts_key))
+            if ts is None:
+                continue
+            try:
+                val = float(str(entry.get(value_key)))
+            except (ValueError, TypeError):
+                continue
+            if not math.isfinite(val):
+                continue
+            numeric.append((ts, val))
+
+    if len(numeric) >= 2:
+        numeric.sort(key=lambda p: p[0])
+        if len(numeric) > _MAX_ATTRIBUTE_POINTS:
+            stride = len(numeric) / _MAX_ATTRIBUTE_POINTS
+            numeric = [
+                numeric[round(i * stride)]
+                for i in range(_MAX_ATTRIBUTE_POINTS)
+            ]
+        return numeric
     return []
 
 
@@ -1109,7 +1217,10 @@ def _normalize_entities(
     or the multi-entity format (``entities`` list of dicts).  When
     both are present ``entities`` takes precedence.  Flat editor keys
     ``entity_2`` / ``entity_3`` are also handled for widgets saved by
-    the editor UI.
+    the editor UI.  These flat secondary-entity keys always default
+    to ``data_source="history"`` because the editor does not expose
+    attribute-source fields for them; use the ``entities`` list
+    format to configure an attribute source on a secondary entity.
 
     Args:
         widget: Widget config dict.
@@ -1118,10 +1229,14 @@ def _normalize_entities(
         List of entity descriptor dicts, each with keys ``entity``
         (str), ``name`` (str, empty when not overridden), ``y_axis``
         (``"primary"`` or ``"secondary"``), ``line_style``
-        (``"solid"``, ``"dashed"``, or ``"dotted"``), and ``dash``
-        (the SVG ``stroke-dasharray`` value, empty for solid).
-        Maximum 3 entries.  Returns an empty list when no entity
-        source is found.
+        (``"solid"``, ``"dashed"``, or ``"dotted"``), ``dash``
+        (the SVG ``stroke-dasharray`` value, empty for solid),
+        ``data_source`` (``"history"`` or ``"attribute"``),
+        ``attribute`` (str, the attribute name holding a time-series
+        list when ``data_source`` is ``"attribute"``),
+        ``attribute_timestamp_key`` (str, default ``"timestamp"``),
+        and ``attribute_value_key`` (str).  Maximum 3 entries.
+        Returns an empty list when no entity source is found.
     """
     _STYLE_MAP: dict[str, int] = {"solid": 0, "dashed": 1, "dotted": 2}
     raw: list[dict[str, object]] = []
@@ -1142,7 +1257,19 @@ def _normalize_entities(
     else:
         eid = str(widget.get("entity", ""))
         if eid:
-            raw.append({"entity": eid})
+            raw.append(
+                {
+                    "entity": eid,
+                    "data_source": str(widget.get("data_source", "history")),
+                    "attribute": str(widget.get("attribute", "")),
+                    "attribute_timestamp_key": str(
+                        widget.get("attribute_timestamp_key", "timestamp")
+                    ),
+                    "attribute_value_key": str(
+                        widget.get("attribute_value_key", "")
+                    ),
+                }
+            )
         for suffix in ("_2", "_3"):
             eid2 = str(widget.get(f"entity{suffix}", ""))
             if eid2:
@@ -1169,6 +1296,14 @@ def _normalize_entities(
                 "y_axis": str(item.get("y_axis", "primary")),
                 "line_style": style_name,
                 "dash": _DASH_PATTERNS[idx],
+                "data_source": str(item.get("data_source", "history")),
+                "attribute": str(item.get("attribute", "")),
+                "attribute_timestamp_key": str(
+                    item.get("attribute_timestamp_key", "timestamp")
+                ),
+                "attribute_value_key": str(
+                    item.get("attribute_value_key", "")
+                ),
             }
         )
     return result
@@ -1358,18 +1493,27 @@ def _build_graph_context(
     gy1 = header_h + margin
     gy2 = svg_h - margin
 
-    # --- Per-entity history extraction ---
+    # --- Per-entity data extraction ---
+    # Entities with data_source="attribute" read a forecast-style
+    # time-series list from a named entity attribute instead of the
+    # recorder's state history.
     states_dict: dict[str, object] = config.get("states", {})
-    per_entity_points: list[list[tuple[float, float]]] = [
-        _extract_entity_points(
-            desc,
-            states_dict,
-            hours_to_show,
-            points_per_hour,
-            aggregate_func,
-        )
-        for desc in entity_descs
-    ]
+    per_entity_points: list[list[tuple[float, float]]] = []
+    for desc in entity_descs:
+        if str(desc.get("data_source", "history")) == "attribute":
+            per_entity_points.append(
+                _extract_attribute_points(desc, states_dict)
+            )
+        else:
+            per_entity_points.append(
+                _extract_entity_points(
+                    desc,
+                    states_dict,
+                    hours_to_show,
+                    points_per_hour,
+                    aggregate_func,
+                )
+            )
 
     # --- Y bounds per axis ---
     primary_values: list[float] = []

--- a/tests/test_render_graph.py
+++ b/tests/test_render_graph.py
@@ -92,6 +92,17 @@ _NARROW_HISTORY = [
     {"s": "20.5", "lu": 1747699200.0},
 ]
 
+# Attribute-based forecast data: a solar production forecast stored
+# as a list under the "timeseries" attribute, ISO 8601 timestamps
+# with UTC offset, "w" holding the numeric wattage value.
+_FORECAST_TIMESERIES = [
+    {"timestamp": "2026-07-01T04:00:00+00:00", "w": 100.0},
+    {"timestamp": "2026-07-01T04:15:00+00:00", "w": 250.0},
+    {"timestamp": "2026-07-01T04:30:00+00:00", "w": 400.0},
+    {"timestamp": "2026-07-01T04:45:00+00:00", "w": 600.0},
+    {"timestamp": "2026-07-01T05:00:00+00:00", "w": 800.0},
+]
+
 MOCK_GRAPH_STATES: dict[str, dict[str, object]] = {
     "sensor.temperature": {
         "state": "22.5",
@@ -128,6 +139,14 @@ MOCK_GRAPH_STATES: dict[str, dict[str, object]] = {
             {"s": "1015.0", "lu": 1747699200.0},
         ],
     },
+    "sensor.solar_forecast": {
+        "state": "800.0",
+        "attributes": {
+            "friendly_name": "Solar Forecast",
+            "unit_of_measurement": "W",
+            "timeseries": _FORECAST_TIMESERIES,
+        },
+    },
 }
 
 
@@ -146,6 +165,12 @@ class TestRenderGraph:
 
     Phase 4 adds bar chart mode (graph="bar") with grouped multi-entity
     bars, distinct fill shades, and <rect> legend swatches.
+
+    Phase 5 adds color thresholds for line and bar modes.
+
+    Phase 6 adds an attribute-based data source, letting entities
+    read a time-series list from a named attribute (e.g. a solar or
+    price forecast) instead of the recorder's state history.
     """
 
     _DEFAULTS: ClassVar[dict[str, object]] = {
@@ -544,6 +569,61 @@ class TestRenderGraph:
         m = re.search(r'height="(\d+)"', svg)
         assert m is not None
         assert int(m.group(1)) == 200
+
+    def test_graph_history_nan_inf_filtered(self) -> None:
+        # History entries with NaN or Infinity state values are
+        # silently dropped; valid entries still render a polyline.
+        history = [
+            {"s": "nan", "lu": 1747620000.0},
+            {"s": "inf", "lu": 1747623600.0},
+            {"s": "-inf", "lu": 1747627200.0},
+            {"s": "20.0", "lu": 1747634400.0},
+            {"s": "22.5", "lu": 1747656000.0},
+            {"s": "21.0", "lu": 1747699200.0},
+        ]
+        states: dict[str, dict[str, object]] = {
+            "sensor.temperature": {
+                "state": "21.0",
+                "attributes": {
+                    "friendly_name": "Living Room",
+                    "device_class": "temperature",
+                    "unit_of_measurement": "°C",
+                },
+                "history": history,
+            }
+        }
+        svg = render_widget_svg(
+            self._base_widget(smoothing=False),
+            self._config(states=states),
+        )
+        assert "<polyline" in svg
+
+    def test_graph_history_nan_timestamp_filtered(self) -> None:
+        # History entries with NaN/inf in the lu (timestamp) field are
+        # dropped without corrupting the time-window computation.
+        history = [
+            {"s": "20.0", "lu": "nan"},
+            {"s": "21.0", "lu": float("inf")},
+            {"s": "22.5", "lu": 1747620000.0},
+            {"s": "23.0", "lu": 1747645200.0},
+            {"s": "22.0", "lu": 1747699200.0},
+        ]
+        states: dict[str, dict[str, object]] = {
+            "sensor.temperature": {
+                "state": "22.0",
+                "attributes": {
+                    "friendly_name": "Living Room",
+                    "device_class": "temperature",
+                    "unit_of_measurement": "°C",
+                },
+                "history": history,
+            }
+        }
+        svg = render_widget_svg(
+            self._base_widget(smoothing=False),
+            self._config(states=states),
+        )
+        assert "<polyline" in svg
 
     # ── Phase 2: Smoothing tests ───────────────────────────────────────
 
@@ -1812,6 +1892,279 @@ class TestRenderGraph:
             self._threshold_config(),
         )
         assert svg_list_only == svg_both
+
+    # ── Phase 6: Attribute data source ────────────────────────────────
+
+    def _attribute_widget(self, **overrides: object) -> dict[str, object]:
+        """Return a graph widget reading sensor.solar_forecast."""
+        w: dict[str, object] = {
+            "type": "graph",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 280,
+            "entity": "sensor.solar_forecast",
+            "data_source": "attribute",
+            "attribute": "timeseries",
+            "attribute_value_key": "w",
+            "smoothing": False,
+        }
+        w.update(overrides)
+        return w
+
+    def test_graph_attribute_source_renders_polyline(self) -> None:
+        # data_source="attribute" reads the named attribute list and
+        # renders a polyline from its (timestamp, value) entries.
+        svg = render_widget_svg(self._attribute_widget(), self._config())
+        assert "<polyline" in svg
+
+    def test_graph_attribute_source_missing_attribute_no_polyline(
+        self,
+    ) -> None:
+        # When the configured attribute is absent from entity state,
+        # no polyline is rendered and the SVG remains valid.
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "0.0",
+                "attributes": {"friendly_name": "Solar Forecast"},
+            }
+        }
+        svg = render_widget_svg(
+            self._attribute_widget(), self._config(states=states)
+        )
+        assert "<svg" in svg
+        assert "<polyline" not in svg
+
+    def test_graph_attribute_source_non_numeric_filtered(self) -> None:
+        # Non-numeric values in the attribute list are skipped; a
+        # graph still renders when at least 2 numeric entries survive.
+        mixed = [
+            {"timestamp": "2026-07-01T04:00:00+00:00", "w": "unknown"},
+            {"timestamp": "2026-07-01T04:15:00+00:00", "w": 250.0},
+            {"timestamp": "2026-07-01T04:30:00+00:00", "w": None},
+            {"timestamp": "2026-07-01T04:45:00+00:00", "w": 600.0},
+        ]
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "600.0",
+                "attributes": {
+                    "friendly_name": "Solar Forecast",
+                    "timeseries": mixed,
+                },
+            }
+        }
+        svg = render_widget_svg(
+            self._attribute_widget(), self._config(states=states)
+        )
+        assert "<polyline" in svg
+
+    def test_graph_attribute_source_fewer_than_two_points_no_graph(
+        self,
+    ) -> None:
+        # A single valid data point is insufficient to draw a line;
+        # no polyline is rendered.
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "100.0",
+                "attributes": {
+                    "friendly_name": "Solar Forecast",
+                    "timeseries": [
+                        {
+                            "timestamp": "2026-07-01T04:00:00+00:00",
+                            "w": 100.0,
+                        },
+                    ],
+                },
+            }
+        }
+        svg = render_widget_svg(
+            self._attribute_widget(), self._config(states=states)
+        )
+        assert "<polyline" not in svg
+
+    def test_graph_attribute_source_unix_timestamps(self) -> None:
+        # Unix timestamp floats (instead of ISO 8601 strings) are
+        # parsed correctly and produce a polyline.
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "800.0",
+                "attributes": {
+                    "friendly_name": "Solar Forecast",
+                    "timeseries": [
+                        {"timestamp": 1747620000.0, "w": 100.0},
+                        {"timestamp": 1747623600.0, "w": 400.0},
+                        {"timestamp": 1747627200.0, "w": 800.0},
+                    ],
+                },
+            }
+        }
+        svg = render_widget_svg(
+            self._attribute_widget(), self._config(states=states)
+        )
+        assert "<polyline" in svg
+
+    def test_graph_attribute_source_custom_keys(self) -> None:
+        # Custom attribute_timestamp_key and attribute_value_key
+        # read from differently-named fields in the attribute list.
+        states: dict[str, dict[str, object]] = {
+            "sensor.price_forecast": {
+                "state": "0.30",
+                "attributes": {
+                    "friendly_name": "Price Forecast",
+                    "prices": [
+                        {"time": "2026-07-01T04:00:00+00:00", "p": 0.10},
+                        {"time": "2026-07-01T05:00:00+00:00", "p": 0.30},
+                    ],
+                },
+            }
+        }
+        widget = self._attribute_widget(
+            entity="sensor.price_forecast",
+            attribute="prices",
+            attribute_timestamp_key="time",
+            attribute_value_key="p",
+        )
+        svg = render_widget_svg(widget, self._config(states=states))
+        assert "<polyline" in svg
+
+    def test_graph_attribute_default_data_source_is_history(self) -> None:
+        # Omitting data_source defaults to "history" — an entity
+        # exposing only an attribute-based timeseries (no recorder
+        # history) produces no polyline under the default source.
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "800.0",
+                "attributes": {
+                    "friendly_name": "Solar Forecast",
+                    "timeseries": _FORECAST_TIMESERIES,
+                },
+            }
+        }
+        widget: dict[str, object] = {
+            "type": "graph",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 280,
+            "entity": "sensor.solar_forecast",
+            "attribute": "timeseries",
+            "attribute_value_key": "w",
+            "smoothing": False,
+        }
+        svg = render_widget_svg(widget, self._config(states=states))
+        assert "<polyline" not in svg
+
+    def test_graph_attribute_source_mixed_with_history(self) -> None:
+        # One entity reads recorder history, the other reads an
+        # attribute-based forecast; both series render as separate
+        # polylines on the same graph.
+        widget: dict[str, object] = {
+            "type": "graph",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 280,
+            "entities": [
+                {"entity": "sensor.temperature"},
+                {
+                    "entity": "sensor.solar_forecast",
+                    "data_source": "attribute",
+                    "attribute": "timeseries",
+                    "attribute_value_key": "w",
+                },
+            ],
+            "smoothing": False,
+        }
+        svg = render_widget_svg(widget, self._config())
+        assert svg.count("<polyline") == 2
+
+    def test_graph_attribute_source_bar_mode(self) -> None:
+        # Attribute-sourced data also works in bar chart mode.
+        widget = self._attribute_widget(graph="bar")
+        svg = render_widget_svg(widget, self._config())
+        assert "<rect" in svg
+
+    def test_graph_attribute_source_extrema(self) -> None:
+        # show_extrema works with attribute-sourced data, displaying
+        # min/max value labels below the graph.
+        widget = self._attribute_widget(show_extrema=True)
+        svg = render_widget_svg(widget, self._config())
+        assert "Min:" in svg
+        assert "Max:" in svg
+
+    def test_graph_attribute_source_nan_inf_filtered(self) -> None:
+        # Entries with NaN/Infinity in timestamp or value are
+        # silently dropped; a graph still renders from the remaining
+        # valid points.
+        mixed = [
+            {"timestamp": "2026-07-01T04:00:00+00:00", "w": float("nan")},
+            {"timestamp": "nan", "w": 250.0},
+            {"timestamp": "2026-07-01T04:15:00+00:00", "w": float("inf")},
+            {"timestamp": "inf", "w": 300.0},
+            {"timestamp": "2026-07-01T04:30:00+00:00", "w": 400.0},
+            {"timestamp": "2026-07-01T04:45:00+00:00", "w": 600.0},
+            {"timestamp": "2026-07-01T05:00:00+00:00", "w": float("-inf")},
+        ]
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "600.0",
+                "attributes": {
+                    "friendly_name": "Solar Forecast",
+                    "timeseries": mixed,
+                },
+            }
+        }
+        svg = render_widget_svg(
+            self._attribute_widget(), self._config(states=states)
+        )
+        assert "<polyline" in svg
+
+    def test_graph_attribute_source_non_list_attribute_no_graph(
+        self,
+    ) -> None:
+        # When the attribute value is not a list (e.g. an int, dict,
+        # or string), no polyline is rendered.
+        for bad_value in (42, {"nested": "dict"}, "just a string"):
+            states: dict[str, dict[str, object]] = {
+                "sensor.solar_forecast": {
+                    "state": "0.0",
+                    "attributes": {
+                        "friendly_name": "Solar Forecast",
+                        "timeseries": bad_value,
+                    },
+                }
+            }
+            svg = render_widget_svg(
+                self._attribute_widget(), self._config(states=states)
+            )
+            assert "<svg" in svg
+            assert "<polyline" not in svg
+
+    def test_graph_attribute_source_non_dict_entries_filtered(
+        self,
+    ) -> None:
+        # List entries that are not dicts (plain strings, ints, None)
+        # are skipped; valid dicts still render.
+        mixed = [
+            "just a string",
+            42,
+            None,
+            {"timestamp": "2026-07-01T04:00:00+00:00", "w": 400.0},
+            {"timestamp": "2026-07-01T04:15:00+00:00", "w": 600.0},
+        ]
+        states: dict[str, dict[str, object]] = {
+            "sensor.solar_forecast": {
+                "state": "600.0",
+                "attributes": {
+                    "friendly_name": "Solar Forecast",
+                    "timeseries": mixed,
+                },
+            }
+        }
+        svg = render_widget_svg(
+            self._attribute_widget(), self._config(states=states)
+        )
+        assert "<polyline" in svg
 
     # ── Unit tests for threshold helper functions ──────────────────────
 


### PR DESCRIPTION
Lets graph entities read a time-series list from a named entity
attribute (e.g. solar production or price forecasts) instead of
only the recorder's state history.

Fixes #66