### PR TITLE
feature: add invert_condition option for inverted rendering of tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`invert_condition`** option on the Tile widget: a list of
+  Lovelace condition dicts, same format as `visibility`. When the
+  conditions are met the tile renders inverted (solid black card,
+  white text/icon) as an e-ink "needs attention" signal.
+
 ## [0.6.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,7 +169,14 @@ The component ships a WYSIWYG Lovelace card for editing the dashboard layout.
 | [Waste Schedule](docs/waste_schedule.md) | Upcoming waste collection dates (today, tomorrow, in N days) |
 
 All widgets support `x`, `y` positioning. Most support a `w` (width) override
-to constrain rendering to a sub-region of the display.
+to constrain rendering to a sub-region of the display. All widgets also
+support a `visibility` list of Lovelace conditions to show or hide the
+widget based on entity state or other conditions.
+
+The Tile widget additionally supports `invert_condition` — a list of
+conditions in the same format as `visibility`. When met, the tile renders
+inverted (solid black card, white text/icon) as a "needs attention" signal
+on e-ink.
 
 ## Device setup
 

--- a/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
+++ b/custom_components/eink_dashboard/frontend/src/eink-dashboard-editor.ts
@@ -2265,6 +2265,17 @@ class EinkDashboardEditor extends HTMLElement {
         if (!("visibility" in data) && cur.visibility) {
           data.visibility = cur.visibility;
         }
+        // Preserve invert_condition — managed by
+        // ha-card-conditions-editor, not by ha-form, so the spread
+        // would drop it. cur.invert_condition is never [] because
+        // _buildConditionsPanel deletes the key when conditions are
+        // cleared (empty array).
+        if (
+          !("invert_condition" in data)
+          && cur.invert_condition
+        ) {
+          data.invert_condition = cur.invert_condition;
+        }
         this._widgets[index] = data as unknown as Widget;
         this._fireWidgetChange();
         this._updateSummary(index);
@@ -2283,6 +2294,17 @@ class EinkDashboardEditor extends HTMLElement {
 
     if (widget.type === "waste_schedule") {
       this._buildEntriesEditor(container, index);
+    }
+
+    if (widget.type === "tile") {
+      this._buildConditionsPanel(container, index, {
+        key: "invert_condition",
+        title: "Invert",
+        icon: "mdi:invert-colors",
+        hint:
+          "Render the tile inverted (dark card, light text) when" +
+          " the conditions below are met.",
+      });
     }
 
     this._buildVisibilityEditor(container, index);
@@ -2507,17 +2529,15 @@ class EinkDashboardEditor extends HTMLElement {
     container.appendChild(section);
   }
 
-  // ── Visibility conditions editor ────────────────────────────────
+  // ── Visibility / invert conditions editor ──────────────────────
 
   /**
    * Build a visibility conditions editor using HA's built-in
    * `<ha-card-conditions-editor>` component.  Appended to every
    * widget form regardless of widget type.
    *
-   * Reads the current widget's `visibility` array, passes it to the
-   * conditions editor, and writes changes back on `value-changed`.
-   * An empty conditions array is stored as `undefined` (field
-   * removed) to avoid serialising empty arrays.
+   * Thin wrapper around `_buildConditionsPanel` for the `visibility`
+   * field — see that method for the shared behaviour.
    *
    * @param container - Parent div to append the section to.
    * @param index     - Widget index in the widget array.
@@ -2526,9 +2546,41 @@ class EinkDashboardEditor extends HTMLElement {
     container: HTMLElement,
     index: number,
   ): void {
+    this._buildConditionsPanel(container, index, {
+      key: "visibility",
+      title: "Visibility",
+      icon: "mdi:eye",
+      hint: "Show this widget only when the conditions below are met.",
+    });
+  }
+
+  /**
+   * Build a conditions editor panel using HA's built-in
+   * `<ha-card-conditions-editor>` component, backed by an arbitrary
+   * widget field (e.g. `visibility` or `invert_condition`).
+   *
+   * Reads the current widget's condition array at `opts.key`, passes
+   * it to the conditions editor, and writes changes back on
+   * `value-changed`. An empty conditions array is stored as
+   * `undefined` (field removed) to avoid serialising empty arrays.
+   *
+   * @param container - Parent div to append the section to.
+   * @param index     - Widget index in the widget array.
+   * @param opts      - Field key plus panel title/icon/hint text.
+   */
+  private _buildConditionsPanel(
+    container: HTMLElement,
+    index: number,
+    opts: {
+      key: "visibility" | "invert_condition";
+      title: string;
+      icon: string;
+      hint: string;
+    },
+  ): void {
     const panel = document.createElement("ha-expansion-panel");
     (panel as unknown as Record<string, unknown>).outlined = true;
-    // ha-form sections have internal spacing; the visibility panel
+    // ha-form sections have internal spacing; the conditions panel
     // is appended outside ha-form so it needs an explicit top gap.
     panel.style.marginTop = "8px";
 
@@ -2536,29 +2588,29 @@ class EinkDashboardEditor extends HTMLElement {
     // title in "header" slot.
     const icon = document.createElement("ha-icon");
     icon.setAttribute("slot", "leading-icon");
-    (icon as unknown as Record<string, unknown>).icon = "mdi:eye";
+    (icon as unknown as Record<string, unknown>).icon = opts.icon;
     panel.appendChild(icon);
 
     const panelHeader = document.createElement("div");
     panelHeader.setAttribute("slot", "header");
-    panelHeader.textContent = "Visibility";
+    panelHeader.textContent = opts.title;
     panel.appendChild(panelHeader);
 
     const hint = document.createElement("div");
     hint.className = "visibility-hint";
-    hint.textContent =
-      "Show this widget only when the conditions below are met.";
+    hint.textContent = opts.hint;
     panel.appendChild(hint);
 
     if (!customElements.get("ha-card-conditions-editor")) {
       console.warn(
         "eink-dashboard: ha-card-conditions-editor not registered;" +
-          " visibility editing unavailable",
+          ` ${opts.title.toLowerCase()} editing unavailable`,
       );
       const unavailable = document.createElement("div");
       unavailable.className = "visibility-hint";
       unavailable.textContent =
-        "Visibility conditions require a newer Home Assistant version.";
+        `${opts.title} conditions require a newer Home Assistant` +
+        " version.";
       panel.appendChild(unavailable);
       container.appendChild(panel);
       return;
@@ -2570,7 +2622,7 @@ class EinkDashboardEditor extends HTMLElement {
     const cur = this._widgets[index] as
       unknown as Record<string, unknown>;
     const conditions =
-      (cur.visibility as (Condition | LegacyCondition)[] | undefined)
+      (cur[opts.key] as (Condition | LegacyCondition)[] | undefined)
       ?? [];
     (editor as unknown as Record<string, unknown>).hass = this._hass;
     (editor as unknown as Record<string, unknown>).conditions =
@@ -2586,9 +2638,9 @@ class EinkDashboardEditor extends HTMLElement {
         const w = this._widgets[index] as
           unknown as Record<string, unknown>;
         if (updated.length > 0) {
-          w.visibility = updated;
+          w[opts.key] = updated;
         } else {
-          delete w.visibility;
+          delete w[opts.key];
         }
         // Write back so the Lit component re-renders immediately,
         // showing newly added condition fields without a save+reopen.

--- a/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
+++ b/custom_components/eink_dashboard/frontend/src/types/ha.d.ts
@@ -528,6 +528,13 @@ export interface TileWidget extends WidgetBase {
   icon_style?: IconStyle;
   /** When true, renders the secondary state line in bold. */
   bold_value?: boolean;
+  /**
+   * HA conditions that trigger inverted rendering (black card,
+   * white text) as an e-ink attention signal. Same condition
+   * format as `visibility`. The tile renders inverted when the
+   * conditions are met.
+   */
+  invert_condition?: (Condition | LegacyCondition)[];
 }
 
 /**

--- a/custom_components/eink_dashboard/frontend/test/eink-dashboard-editor.test.ts
+++ b/custom_components/eink_dashboard/frontend/test/eink-dashboard-editor.test.ts
@@ -594,3 +594,243 @@ describe("Visibility field", () => {
     expect(widget.visibility).toBeUndefined();
   });
 });
+
+// ── Invert condition panel (tile widgets) ───────────────────────────
+
+// Stub HA's <ha-card-conditions-editor> Lit component so the editor's
+// conditions panel builder takes its normal path instead of the
+// "component unavailable" fallback. Tests dispatch value-changed
+// events on this stub directly to exercise the write-back logic.
+if (!customElements.get("ha-card-conditions-editor")) {
+  customElements.define(
+    "ha-card-conditions-editor",
+    class extends HTMLElement {},
+  );
+}
+
+/**
+ * Click a widget row's expand button and wait for the resulting
+ * synchronous re-render to settle.
+ *
+ * @param editor - The editor element under test.
+ * @param index  - Widget index to expand.
+ */
+async function expandWidget(
+  editor: EinkEditorElement,
+  index: number,
+): Promise<void> {
+  const btn = editor.shadowRoot!.querySelector<HTMLButtonElement>(
+    `.widget-item[data-index="${index}"] .icon-btn.expand`,
+  );
+  btn!.click();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+/**
+ * Find a conditions panel's `header` slot element by its title text.
+ *
+ * @param editor - The editor element under test.
+ * @param title  - Panel title to search for (e.g. "Invert").
+ * @returns The matching header div, or null if no panel has it.
+ */
+function findPanelHeader(
+  editor: EinkEditorElement,
+  title: string,
+): HTMLElement | null {
+  const headers = editor.shadowRoot!.querySelectorAll<HTMLElement>(
+    'div[slot="header"]',
+  );
+  for (const header of Array.from(headers)) {
+    if (header.textContent === title) return header;
+  }
+  return null;
+}
+
+/** Create and mount a bare editor element for DOM-level tests. */
+async function mountEditor(
+  widgets: Widget[],
+): Promise<EinkEditorElement> {
+  const editor = document.createElement(
+    "eink-dashboard-editor",
+  ) as EinkEditorElement;
+  document.body.appendChild(editor);
+  editor.setDisplay({ width: 800, height: 480 });
+  editor.setWidgets(widgets);
+  await new Promise((r) => setTimeout(r, 0));
+  return editor;
+}
+
+describe("Invert condition panel (tile widgets)", () => {
+  it("appears for tile widgets", async () => {
+    // The Invert panel is tile-specific — it must render when a
+    // tile widget row is expanded.
+    const editor = await mountEditor([
+      { type: "tile", entity: "sensor.x" },
+    ]);
+    await expandWidget(editor, 0);
+    expect(findPanelHeader(editor, "Invert")).toBeTruthy();
+  });
+
+  it("does not appear for non-tile widgets", async () => {
+    // Non-tile widgets have no invert-on-condition rendering, so the
+    // panel must be absent, while the Visibility panel still shows.
+    const editor = await mountEditor([
+      { type: "separator" },
+    ]);
+    await expandWidget(editor, 0);
+    expect(findPanelHeader(editor, "Invert")).toBeNull();
+    expect(findPanelHeader(editor, "Visibility")).toBeTruthy();
+  });
+
+  it("visibility panel still appears alongside Invert for tiles", async () => {
+    // Widget forms append both panels for tiles: Invert first, then
+    // Visibility (order also matches the source instructions).
+    const editor = await mountEditor([
+      { type: "tile", entity: "sensor.x" },
+    ]);
+    await expandWidget(editor, 0);
+    expect(findPanelHeader(editor, "Invert")).toBeTruthy();
+    expect(findPanelHeader(editor, "Visibility")).toBeTruthy();
+  });
+
+  it(
+    "value-changed on the invert editor writes invert_condition",
+    async () => {
+      // Simulates the user adding a condition in the conditions
+      // editor: the panel must write it to widget.invert_condition.
+      const editor = await mountEditor([
+        { type: "tile", entity: "sensor.x" },
+      ]);
+      await expandWidget(editor, 0);
+
+      const header = findPanelHeader(editor, "Invert")!;
+      const panel = header.parentElement!;
+      const conditionsEditor = panel.querySelector(
+        "ha-card-conditions-editor",
+      )!;
+
+      let received: Widget[] | undefined;
+      editor.addEventListener(
+        "widget-change",
+        ((ev: CustomEvent<{ widgets: Widget[] }>) => {
+          received = ev.detail.widgets;
+        }) as EventListener,
+      );
+
+      const condition: StateCondition = {
+        condition: "state",
+        entity: "sensor.test",
+        state: "on",
+      };
+      conditionsEditor.dispatchEvent(
+        new CustomEvent("value-changed", {
+          detail: { value: [condition] },
+        }),
+      );
+
+      expect(received).toBeDefined();
+      expect(received![0].invert_condition).toEqual([condition]);
+    },
+  );
+
+  it(
+    "clearing invert conditions to an empty array deletes the key",
+    async () => {
+      // An empty conditions array must not be serialised — the key
+      // is removed entirely, mirroring the visibility field.
+      const condition: StateCondition = {
+        condition: "state",
+        entity: "sensor.test",
+        state: "on",
+      };
+      const editor = await mountEditor([
+        {
+          type: "tile",
+          entity: "sensor.x",
+          invert_condition: [condition],
+        },
+      ]);
+      await expandWidget(editor, 0);
+
+      const header = findPanelHeader(editor, "Invert")!;
+      const panel = header.parentElement!;
+      const conditionsEditor = panel.querySelector(
+        "ha-card-conditions-editor",
+      )!;
+
+      let received: Widget[] | undefined;
+      editor.addEventListener(
+        "widget-change",
+        ((ev: CustomEvent<{ widgets: Widget[] }>) => {
+          received = ev.detail.widgets;
+        }) as EventListener,
+      );
+
+      conditionsEditor.dispatchEvent(
+        new CustomEvent("value-changed", {
+          detail: { value: [] },
+        }),
+      );
+
+      expect(received).toBeDefined();
+      expect(received![0].invert_condition).toBeUndefined();
+      expect("invert_condition" in received![0]).toBe(false);
+    },
+  );
+
+  it(
+    "ha-form edit on a tile preserves invert_condition and visibility",
+    async () => {
+      // ha-form only knows about schema fields, so its value-changed
+      // handler must explicitly re-attach invert_condition and
+      // visibility or they would be dropped by the data rebuild.
+      const invertCondition: StateCondition = {
+        condition: "state",
+        entity: "sensor.invert-source",
+        state: "on",
+      };
+      const visibilityCondition: StateCondition = {
+        condition: "state",
+        entity: "sensor.visibility-source",
+        state: "on",
+      };
+      const editor = await mountEditor([
+        {
+          type: "tile",
+          entity: "sensor.x",
+          invert_condition: [invertCondition],
+          visibility: [visibilityCondition],
+        },
+      ]);
+      await expandWidget(editor, 0);
+
+      const form = editor.shadowRoot!.querySelector(
+        '.widget-item[data-index="0"] ha-form',
+      )!;
+
+      let received: Widget[] | undefined;
+      editor.addEventListener(
+        "widget-change",
+        ((ev: CustomEvent<{ widgets: Widget[] }>) => {
+          received = ev.detail.widgets;
+        }) as EventListener,
+      );
+
+      // Simulate ha-form emitting a rebuilt value that only contains
+      // schema-known fields — invert_condition/visibility are absent.
+      form.dispatchEvent(
+        new CustomEvent("value-changed", {
+          detail: { value: { entity: "sensor.y" } },
+        }),
+      );
+
+      expect(received).toBeDefined();
+      const widget = received![0] as Widget & {
+        invert_condition?: unknown;
+      };
+      expect(widget.entity).toBe("sensor.y");
+      expect(widget.invert_condition).toEqual([invertCondition]);
+      expect(widget.visibility).toEqual([visibilityCondition]);
+    },
+  );
+});

--- a/custom_components/eink_dashboard/templates/tile.svg.j2
+++ b/custom_components/eink_dashboard/templates/tile.svg.j2
@@ -2,6 +2,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      width="{{ w }}" height="{{ h }}">
 {%- if has_entity -%}
+{%- if invert -%}
+<rect x="0" y="0" width="{{ w }}" height="{{ h }}"
+  rx="{{ m_radius }}" ry="{{ m_radius }}"
+  fill="{{ hex_black }}"/>
+{%- endif -%}
 {%- call card_container(
     x=0, y=0, w=w, h=h,
     card_style=card_style,
@@ -26,13 +31,14 @@
     icon_fill=icon_fill,
     icon_outline=icon_outline,
     icon_no_circle=icon_no_circle,
-    primary_fill=hex_gray,
-    secondary_fill=hex_black,
-    value_fill=hex_black,
+    primary_fill=hex_white if invert else hex_gray,
+    secondary_fill=hex_white if invert else hex_black,
+    value_fill=hex_white if invert else hex_black,
     secondary_bold=value_bold,
     letter=letter,
     lpad=lpad, rpad=rpad,
-    hex_black=hex_black, hex_white=hex_white) }}
+    hex_black=hex_white if invert else hex_black,
+    hex_white=hex_black if invert else hex_white) }}
 {%- endcall -%}
 {%- endif -%}
 </svg>

--- a/custom_components/eink_dashboard/widgets/tile.py
+++ b/custom_components/eink_dashboard/widgets/tile.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from ..conditions import check_conditions
 from ..const import (
     COLOR_GRAY,
     DEFAULT_CARD_STYLE,
@@ -73,7 +74,11 @@ def _build_tile_context(
             ``icon_style`` (``"filled"`` / ``"outlined"`` /
             ``"none"``), ``bold_value`` (render the secondary
             state line in bold; default ``False``), ``card_style``,
-            ``x``, ``w``, ``h``.
+            ``invert_condition`` (list of Lovelace condition dicts,
+            same format as ``visibility``; when non-empty and all
+            conditions are met the tile renders inverted — solid
+            black card, white text/icon — as an e-ink "needs
+            attention" signal), ``x``, ``w``, ``h``.
         config: Display config with ``width``, ``height``,
             ``states``, and ``grayscale_levels``.
 
@@ -87,9 +92,10 @@ def _build_tile_context(
         strings (``hex_*`` prefix), text content (``primary``,
         ``secondary``), icon data (``icon_svg``, ``letter``),
         and icon style flags (``icon_fill``, ``icon_outline``,
-        ``icon_no_circle``).  The ``card_row`` ``value`` key is
-        intentionally omitted — tiles have no right-aligned
-        value text; the macro defaults to ``""``.
+        ``icon_no_circle``), plus ``invert`` (whether the
+        ``invert_condition`` conditions were met).  The ``card_row``
+        ``value`` key is intentionally omitted — tiles have no
+        right-aligned value text; the macro defaults to ``""``.
     """
     from ..render import _compute_metrics
 
@@ -113,6 +119,7 @@ def _build_tile_context(
             "w": svg_w,
             "h": _widget_dim(widget, "h", DEFAULT_ROW_H),
             "has_entity": False,
+            "invert": False,
             **_color_context(),
         }
 
@@ -180,6 +187,21 @@ def _build_tile_context(
     # dithering.
     icon_stroke_w = m.border * 3 if grayscale_levels <= 2 else m.border
 
+    # Inverted "needs attention" signal: same condition format and
+    # evaluator as `visibility`, but drives a solid black card with
+    # white text/icon instead of hide/show.  `check_conditions([])`
+    # returns True, so the emptiness check is required — an absent
+    # or empty `invert_condition` must never invert the tile.  The
+    # icon is forced to the flat, no-circle style so the glyph draws
+    # cleanly on the black background.
+    invert_condition = widget.get("invert_condition")
+    invert = bool(invert_condition) and check_conditions(
+        invert_condition, states
+    )
+    if invert:
+        icon_no_circle = True
+        icon_outline = False
+
     ctx: dict[str, object] = {
         "w": svg_w,
         "h": svg_h,
@@ -202,6 +224,7 @@ def _build_tile_context(
         "icon_no_circle": icon_no_circle,
         "icon_stroke_w": icon_stroke_w,
         "letter": letter,
+        "invert": invert,
     }
     # When icon is hidden, collapse the icon column so text starts
     # at the left edge.

--- a/tests/test_render_tile.py
+++ b/tests/test_render_tile.py
@@ -26,6 +26,9 @@ from custom_components.eink_dashboard.render import (
     render_dashboard,
 )
 from custom_components.eink_dashboard.svg_render import render_widget_svg
+from custom_components.eink_dashboard.widgets.tile import (
+    _build_tile_context,
+)
 from tests.helpers import (
     _icon_ring_region,
     assert_all_white,
@@ -904,3 +907,269 @@ class TestRenderTile:
             DEFAULT_ROW_H,
             threshold=200,
         )
+
+    # ── Invert condition tests ────────────────────────
+
+    def test_tile_invert_condition_met(self) -> None:
+        # A state condition that matches the entity's current state
+        # inverts the tile: context has invert=True and the SVG
+        # gains a full-size black background rect plus white text.
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "binary_sensor.motion",
+            "invert_condition": [
+                {
+                    "condition": "state",
+                    "entity": "binary_sensor.motion",
+                    "state": "on",
+                }
+            ],
+        }
+        ctx = _build_tile_context(widget, self._config())
+        assert ctx["invert"] is True
+        svg = render_widget_svg(widget, self._config())
+        assert re.search(
+            r'<rect x="0" y="0" width="400" height="80"\s*'
+            r'rx="\d+" ry="\d+"\s*fill="#000000"/>',
+            svg,
+        ), "inverted tile must draw a full-size black background rect"
+        assert 'fill="#ffffff"' in svg, (
+            "inverted tile must render text/icon in white"
+        )
+
+    def test_tile_invert_condition_not_met(self) -> None:
+        # A state condition that does not match leaves the tile
+        # un-inverted: no black background, white canvas outside
+        # content.
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "binary_sensor.front_door",
+            "invert_condition": [
+                {
+                    "condition": "state",
+                    "entity": "binary_sensor.front_door",
+                    "state": "on",
+                }
+            ],
+        }
+        ctx = _build_tile_context(widget, self._config())
+        assert ctx["invert"] is False
+        img = render_to_image([widget], self._config())
+        assert_all_white(img, 0, 0, 3, 3)
+
+    def test_tile_invert_condition_absent(self) -> None:
+        # Omitting invert_condition entirely never inverts the tile.
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "binary_sensor.motion",
+        }
+        ctx = _build_tile_context(widget, self._config())
+        assert ctx["invert"] is False
+
+    def test_tile_invert_condition_empty_list(self) -> None:
+        # invert_condition=[] must never invert, even though
+        # check_conditions([]) alone would return True — the tile
+        # widget must special-case emptiness.
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "binary_sensor.motion",
+            "invert_condition": [],
+        }
+        ctx = _build_tile_context(widget, self._config())
+        assert ctx["invert"] is False
+
+    def test_tile_invert_forces_no_circle_icon(self) -> None:
+        # An active entity normally draws a filled icon circle
+        # (<circle> element).  When inverted, the icon style is
+        # forced to no-circle so the glyph draws directly on the
+        # black background.
+        base = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "binary_sensor.motion",
+        }
+        normal_svg = render_widget_svg(base, self._config())
+        assert "<circle" in normal_svg, (
+            "sanity check: active entity normally draws an icon circle"
+        )
+        inverted = {
+            **base,
+            "invert_condition": [
+                {
+                    "condition": "state",
+                    "entity": "binary_sensor.motion",
+                    "state": "on",
+                }
+            ],
+        }
+        ctx = _build_tile_context(inverted, self._config())
+        assert ctx["icon_no_circle"] is True
+        assert ctx["icon_outline"] is False
+        inverted_svg = render_widget_svg(inverted, self._config())
+        assert "<circle" not in inverted_svg, (
+            "inverted tile must suppress the icon circle entirely"
+        )
+
+    def test_tile_invert_numeric_state_condition(self) -> None:
+        # A numeric_state condition (above: 0) inverts when the
+        # entity's state is a positive number.
+        states = {
+            **MOCK_TILE_STATES,
+            "sensor.count": {
+                "state": "2",
+                "attributes": {"friendly_name": "Count"},
+            },
+        }
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "sensor.count",
+            "invert_condition": [
+                {
+                    "condition": "numeric_state",
+                    "entity": "sensor.count",
+                    "above": 0,
+                }
+            ],
+        }
+        ctx = _build_tile_context(widget, self._config(states=states))
+        assert ctx["invert"] is True
+
+    def test_tile_invert_numeric_state_condition_zero(self) -> None:
+        # numeric_state above=0 does not invert when the state is 0
+        # (the exclusive lower bound is not satisfied).
+        states = {
+            **MOCK_TILE_STATES,
+            "sensor.count": {
+                "state": "0",
+                "attributes": {"friendly_name": "Count"},
+            },
+        }
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "sensor.count",
+            "invert_condition": [
+                {
+                    "condition": "numeric_state",
+                    "entity": "sensor.count",
+                    "above": 0,
+                }
+            ],
+        }
+        ctx = _build_tile_context(widget, self._config(states=states))
+        assert ctx["invert"] is False
+
+    def test_tile_invert_numeric_state_condition_non_numeric(
+        self,
+    ) -> None:
+        # numeric_state above=0 does not invert on a non-numeric
+        # state such as "unknown".
+        states = {
+            **MOCK_TILE_STATES,
+            "sensor.count": {
+                "state": "unknown",
+                "attributes": {"friendly_name": "Count"},
+            },
+        }
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "sensor.count",
+            "invert_condition": [
+                {
+                    "condition": "numeric_state",
+                    "entity": "sensor.count",
+                    "above": 0,
+                }
+            ],
+        }
+        ctx = _build_tile_context(widget, self._config(states=states))
+        assert ctx["invert"] is False
+
+    def test_tile_invert_state_not_condition(self) -> None:
+        # state_not inverts when the entity holds a real value, not
+        # one of the excluded placeholder states.
+        states = {
+            **MOCK_TILE_STATES,
+            "sensor.status": {
+                "state": "washing",
+                "attributes": {"friendly_name": "Status"},
+            },
+        }
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "sensor.status",
+            "invert_condition": [
+                {
+                    "condition": "state",
+                    "entity": "sensor.status",
+                    "state_not": ["", "unknown", "unavailable"],
+                }
+            ],
+        }
+        ctx = _build_tile_context(widget, self._config(states=states))
+        assert ctx["invert"] is True
+
+    def test_tile_invert_state_not_condition_excluded(self) -> None:
+        # state_not does not invert for excluded placeholder states:
+        # empty string and "unknown".
+        widget = {
+            "type": "tile",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 80,
+            "entity": "sensor.status",
+            "invert_condition": [
+                {
+                    "condition": "state",
+                    "entity": "sensor.status",
+                    "state_not": ["", "unknown", "unavailable"],
+                }
+            ],
+        }
+        for excluded_state in ("", "unknown"):
+            states = {
+                **MOCK_TILE_STATES,
+                "sensor.status": {
+                    "state": excluded_state,
+                    "attributes": {"friendly_name": "Status"},
+                },
+            }
+            ctx = _build_tile_context(widget, self._config(states=states))
+            assert ctx["invert"] is False, (
+                f"state {excluded_state!r} must not invert"
+            )


### PR DESCRIPTION
#  Add `invert_condition` option for inverted rendering of tiles

- New optional `invert_condition` on tile widgets. When non-empty and
  all conditions are met, the tile renders inverted (solid black card, white
  text/icon, flat no-circle glyph)
- Rationale: on grayscale e-ink there's no color to signal "needs attention",
  and the default tinted icon circle reads as *lower* contrast when active.
- Reuses the full condition system from the visibility feature. The Visibility 
  panel builder was generalized into a shared `_buildConditionsPanel()`.
- Editor: new "Invert" conditions panel on tile widgets, reusing HA's native
  `ha-card-conditions-editor`; 
- Fixes a data-loss issue along the way: the ha-form `value-changed` handler
  drops widget keys ha-form doesn't manage; `invert_condition` is now
  preserved like `visibility` and `entries`.
- Tests: 11 new pytest cases (`test_render_tile.py`), 8 new vitest cases
  (editor panel, write-back, preservation). Full suites pass: pytest 1040,
  ruff, ty, interrogate, tsc, vitest 110.

## Screenshots
### UI
<img width="469" height="440" alt="grafik" src="https://github.com/user-attachments/assets/c03391f6-4d16-4488-b5bc-d662ea8c7b25" />

### Condition not met
<img width="800" height="480" alt="eink_after" src="https://github.com/user-attachments/assets/d19594e2-ff71-4293-88c6-7a1ddd19324b" />

### Condition met
<img width="800" height="480" alt="eink_invert_test" src="https://github.com/user-attachments/assets/80ca141c-ed62-4007-8f38-ccb1660d5178" />

